### PR TITLE
[DEV-5215] Migrate "modelo educativo" page images

### DIFF
--- a/config/modelo-educativo.json
+++ b/config/modelo-educativo.json
@@ -12,11 +12,11 @@
     "modelo": {
       "desktop":{
         "alt": "imagen",
-        "src": "https://drive.google.com/uc?export=view&id=157rT1VEXOutHETR6olNCo7t6DwxFAVUo"
+        "src": "https://assets.staging.bedu.org/UANE/nosotros_Modelo_Educativo_01_desk_ca70723589.jpg"
       },
       "mobile":{
         "alt": "imagen",
-        "src": "https://drive.google.com/uc?export=view&id=10Y7R-s_qtqLl5NThVIZvSJmWQSRDaC41"
+        "src": "https://assets.staging.bedu.org/UANE/nosotros_Modelo_Educativo_02_movil_8c29ec5635.jpg"
       }
     },
     "descripcion": {


### PR DESCRIPTION
## Issue
 - Migrate images of "modelo educativo" page from drive to S3 bucket

## Solution
 - [feat: modelo educativo images migrated](https://github.com/techlottus/portalverse-uane/pull/97/commits/a7b91451657b4a47b06806c551fd52f5cf642bb8)

## Testing
 - Go to `/nosotros/modelo-educativo`
 - See and compare images with [UANE](https://uane.edu.mx/nosotros/modelo-educativo) website
 - Keep rocking 🔥 