### PR TITLE
[DEV-5227] Migrate "egresados" page images

### DIFF
--- a/config/egresados.json
+++ b/config/egresados.json
@@ -10,9 +10,9 @@
         "title": "ExaUANE", 
         "subtitle": "Estadísticas", 
         "image": {
-          "desktop": "https://drive.google.com/uc?export=view&id=1pLqo240d_ACAIP_mIU57CAep_Asd_nSa",
-          "tablet": "https://drive.google.com/uc?export=view&id=1rMe3GSofFPVTorN9VI9Bvn9CUdtoygMc",
-          "mobile": "https://drive.google.com/uc?export=view&id=1lJ4sw-tmKdpTS3carQuLc-nLfEEXDOkk"
+          "desktop": "https://assets.staging.bedu.org/UANE/egresados_desk_744b3f7151.jpg",
+          "tablet": "https://assets.staging.bedu.org/UANE/egresados_tablet_ffd4fe655f.jpg",
+          "mobile": "https://assets.staging.bedu.org/UANE/egresados_movil_5f02745e69.jpg"
         },
         "statics": [
           {"maxNumber": 50, "icon": "", "prefix": "", "suffix": "mil", "title": "ESTUDIANTES", "body": "egresados de UANE", "container": false, "isShadowColor": false, "bordered": false, "typeShadowColor": "blue-pastel-right", "boxShadow": false},
@@ -46,9 +46,9 @@
     },
     "bannerEmpleabilidad": {
       "image": {
-        "desktop": "https://drive.google.com/uc?export=view&id=1idUUed8QBG8hf9qbpWqm00PmVs-JbGMw",
-        "mobile": "https://drive.google.com/uc?export=view&id=1AouSIC5-YJc0Js1LIRHRxRf03n5ibngx",
-        "tablet": "https://drive.google.com/uc?export=view&id=16G9jZNK2fS1E5tl5pDA-EmB3RVfOi5hr"
+        "desktop": "https://assets.staging.bedu.org/UANE/egresados_empleabilidad_desk_4038ae5849.jpg",
+        "mobile": "https://assets.staging.bedu.org/UANE/egresados_empleabilidad_movil_7d40453bf2.jpg",
+        "tablet": "https://assets.staging.bedu.org/UANE/egresados_empleabilidad_tablet_34cd8baf1f.jpg"
       },
       "font": "",
       "title": "Empleabilidad en UANE",
@@ -74,9 +74,9 @@
     },
     "bannerOfertaEducativa": {
       "image": {
-        "desktop": "https://drive.google.com/uc?export=view&id=1ublCyobsLlz7uKehh34mAfdpQ1or4eYv",
-        "mobile": "https://drive.google.com/uc?export=view&id=190CNvADpywpMXK_QVM6udMb2GsV4HsMt",
-        "tablet": "https://drive.google.com/uc?export=view&id=1-dKm6LNGLTiYVh4bFNe5SFxc1mPffLF9"
+        "desktop": "https://assets.staging.bedu.org/UANE/egresados_oferta_educativa_desk_c7a7a42f3b.jpg",
+        "mobile": "https://assets.staging.bedu.org/UANE/egresados_oferta_educativa_movil_45acccef3c.jpg",
+        "tablet": "https://assets.staging.bedu.org/UANE/egresados_oferta_educativa_tablet_0f534050fb.jpg"
       },
       "font": "light",
       "title": "Oferta educativa de egresados",
@@ -110,8 +110,8 @@
       "bottom": false,
       "left": false,
       "urlImage": {
-        "mobile": "https://drive.google.com/uc?export=view&id=1cXj_pPf0OvVkA7ew-UF--T-L-20FPoOl",
-        "desktop": "https://drive.google.com/uc?export=view&id=1lymiihfxStWQNox-uD9mvh2Ln6GEuUjU"
+        "mobile": "https://assets.staging.bedu.org/UANE/egresados_tramites_movil_a3eef0b837.jpg",
+        "desktop": "https://assets.staging.bedu.org/UANE/egresados_tramites_desk_479e87f64b.jpg"
       },
       "overlay": "black",
       "height": "",
@@ -131,9 +131,9 @@
     },
     "bannerTramites": {
       "image": {
-        "desktop": "https://drive.google.com/uc?export=view&id=1lymiihfxStWQNox-uD9mvh2Ln6GEuUjU",
-        "mobile": "https://drive.google.com/uc?export=view&id=1cXj_pPf0OvVkA7ew-UF--T-L-20FPoOl",
-        "tablet": "https://drive.google.com/uc?export=view&id=1yYRKBIWFTDeyIKXur1aOKx1mPgq3DDDo"
+        "desktop": "https://assets.staging.bedu.org/UANE/egresados_tramites_desk_479e87f64b.jpg",
+        "mobile": "https://assets.staging.bedu.org/UANE/egresados_tramites_movil_a3eef0b837.jpg",
+        "tablet": "https://assets.staging.bedu.org/UANE/egresados_tramites_tablet_cba246258a.jpg"
       },
       "font": "",
       "title": "Trámites de egresados",
@@ -161,7 +161,7 @@
       "title": "Noticias",
       "news": [
         { 
-          "urlImage": "https://drive.google.com/uc?export=view&id=17DFc4e-VEJry-I3puVquu4wxR0m6J6Rw",
+          "urlImage": "https://assets.staging.bedu.org/UANE/egresados_noticias_1_desk_fd9123ac5b.jpg",
           "subtitle": "SUBTITULO",
           "title": "Coursera y UANE se unen para ti",
           "text": "Se firma una alianza con Coursera para acceder a contenidos que complementen la formación profesional de su comunidad educativa",
@@ -193,7 +193,7 @@
           "wrapper": true
         },
         { 
-          "urlImage": "https://drive.google.com/uc?export=view&id=1DlQof6MOk9PQgJtcad50-gb5K3l7WHL_",
+          "urlImage": "https://assets.staging.bedu.org/UANE/egresados_noticias_2_desk_5ef66c0eda.jpg",
           "subtitle": "SUBTITULO",
           "title": "Coursera y UANE se unen para ti",
           "text": "Se firma una alianza con Coursera para acceder a contenidos que complementen la formación profesional de su comunidad educativa",
@@ -229,8 +229,9 @@
     "dudas": {
       "banner":{
         "image": {
-          "desktop": "https://drive.google.com/uc?export=view&id=1jYKPrTuBTGJ1VrYVGhpD7IDeIihrE9SL",
-          "mobile": "https://drive.google.com/uc?export=view&id=1JqS9W5d0AKqVOPSVjti6C1hgJMkysgvf"
+          "desktop": "https://assets.staging.bedu.org/UANE/egresados_contactanos_desk_68320acc5b.jpg",
+          "tablet": "https://assets.staging.bedu.org/UANE/egresados_contactanos_tablet_19984499f4.jpg",
+          "mobile": "https://assets.staging.bedu.org/UANE/egresados_tienes_dudas_movil_af423dc394.jpg"
         },
         "title": "¿Tienes dudas? Contáctanos",
         "subtitle": "Mándanos un mensaje de WhatsApp",


### PR DESCRIPTION
## Issue
 - Migrate images of "egresados page from drive to S3 bucket

## Solution
 - [feat: Egresados page images migrated](https://github.com/techlottus/portalverse-uane/pull/103/commits/a98e1d62dc1719aeaaf1cb09c4b3d9da7a9ce214)

## Testing
 - Go to `/egresados`
 - See and compare images with [UANE](https://uane.edu.mx/egresados) website
 - Keep rocking 🔥 