### PR TITLE
[DEV-5228] Migrate "conexion educativa" page images

### DIFF
--- a/config/conexion-educativa.json
+++ b/config/conexion-educativa.json
@@ -15,11 +15,11 @@
       "image": {
         "desk": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=1-PJN5Uh8k5JEeoTZ1FHZXl5OKav2ADdD"
+          "src": "https://assets.staging.bedu.org/UANE/conexion_vinculacion_desk_93b8e77e4a.jpg"
         },
         "mobile": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=1yVLpuzyMTlGRWa-uT_AikXPW_mCtv03f"
+          "src": "https://assets.staging.bedu.org/UANE/conexion_vinculacion_movil_5c8b47ecd5.jpg"
         }
       },
       "feedback": {
@@ -45,25 +45,25 @@
         {
           "desk": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=13DgmchmaNtN9njb12U5lnREzfLazm-Jl"
+          "src": "https://assets.staging.bedu.org/UANE/lala_9e0aad89e8.jpg"
           }
         },
         {
           "desk": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=1j91hsQpLxTpD1owVhX1A6my729-Gx1SO"
+          "src": "https://assets.staging.bedu.org/UANE/pilgrims_0bbfc8d760.jpg"
           }
         },
         {
           "desk": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=1FArwjQx-NX1rtPdlf-EKZ0ywT2T3cmHb"
+          "src": "https://assets.staging.bedu.org/UANE/gimsa_f1ec55bd55.jpg"
           }
         },
         {
           "desk": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=1gutk5QA3RX6l482uQWuzdawaF14xm7p5"
+          "src": "https://assets.staging.bedu.org/UANE/bahia_principe_bae62b1ae1.jpg"
           }
         }
       ],
@@ -82,7 +82,7 @@
             "content": {
               "image": {
                 "alt": "imagen",
-                "src": "https://drive.google.com/uc?export=view&id=1yWwscqHR-_XtxVu6tB87BXwojRnl9jho"
+                "src": "https://assets.staging.bedu.org/UANE/conexion_servicio_social_desk_080be5f6e4.jpg"
               },
               "content": {
                 "title": "¿Por qué hacer servicio social?",
@@ -103,7 +103,7 @@
             "content": {
               "image": {
                 "alt": "imagen",
-                "src": "https://drive.google.com/uc?export=view&id=1M0m_XSG1KGSJLEZlgzKS-VwerD5uy5He"
+                "src": "https://assets.staging.bedu.org/UANE/conexion_practicas_profesionales_desk_47f4045064.jpg"
               },
               "content": {
                 "title": "¿Por qué hacer prácticas profesionales?",
@@ -125,33 +125,33 @@
     },
     "experiences": {
       "title": "Experiencias UANE",
-      "images": {"images": [{"id": "1", "image": "https://drive.google.com/uc?export=view&id=1NaTkEjWZN2O-ufdoiMic1mYs6KFtDdAX", "icon": "zoom_out_map" }, {"id": "2", "image": "https://drive.google.com/uc?export=view&id=1y4dwIkZ8xf5I93OOISJbDYIzY0E3z85F", "icon": "zoom_out_map" }, {"id": "3", "image": "https://drive.google.com/uc?export=view&id=1fun0SHwAzQpi9iGvmSpLsi-umB-yjPbe", "icon": "zoom_out_map"}, {"id": "4", "image": "https://drive.google.com/uc?export=view&id=1Ssn--66KYAAthWRMTHryb0rRuoXPL6ni", "icon": "zoom_out_map"},{"id": "5", "image": "https://drive.google.com/uc?export=view&id=1E1uOwF3RADySl8H_WO_N8nyBsk_TQ_aj", "icon": "zoom_out_map"}, {"id": "6", "image": "https://drive.google.com/uc?export=view&id=1CyTXqPEg90UD5JGBDxfwW-sy6R_Mw9wf", "icon": "zoom_out_map" }, {"id": "7", "image": "https://drive.google.com/uc?export=view&id=1De_PlYAJA4y82HKOV2Udph2V0VgkriHL", "icon": "zoom_out_map"}, {"id": "8", "image": "https://drive.google.com/uc?export=view&id=19_C3X2-86268UQCZY6aZouyKNIQFW8Ev", "icon": "zoom_out_map"}, {"id": "9", "image": "https://drive.google.com/uc?export=view&id=1PuCzna70a8TDiWIaPH3POL2w3rhz37ay", "icon": "zoom_out_map"}, {"id": "10", "image": "https://drive.google.com/uc?export=view&id=1cGsfKZo4C5YOWaROBP2t8j9HEg0Mn3fH", "icon": "zoom_out_map"}, {"id": "11", "image": "https://drive.google.com/uc?export=view&id=1PBNWit8K484E-HFvaWGGeXiTViCKwEPV", "icon": "zoom_out_map"}, {"id": "12", "image": "https://drive.google.com/uc?export=view&id=1CulfV4b9BwrzgmqFSmwbExYDT_pmsZ6F", "icon": "zoom_out_map"}]}
+      "images": {"images": [{"id": "1", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_1_0c4bb3204e.jpg", "icon": "zoom_out_map" }, {"id": "2", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_2_da9ed133ae.jpg", "icon": "zoom_out_map" }, {"id": "3", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_3_2f2173d9bd.jpg", "icon": "zoom_out_map"}, {"id": "4", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_4_2a4d92c974.jpg", "icon": "zoom_out_map"},{"id": "5", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencia5_05874237f8.jpg", "icon": "zoom_out_map"}, {"id": "6", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_5_b0b3204c45.jpg", "icon": "zoom_out_map" }, {"id": "7", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_7_709e1c200a.jpg", "icon": "zoom_out_map"}, {"id": "8", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_8_3a036f402a.jpg", "icon": "zoom_out_map"}, {"id": "9", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_2_da9ed133ae.jpg", "icon": "zoom_out_map"}, {"id": "10", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_10_0ab188d458.jpg", "icon": "zoom_out_map"}, {"id": "11", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_11_c539459de3.jpg", "icon": "zoom_out_map"}, {"id": "12", "image": "https://assets.staging.bedu.org/UANE/conexion_experiencias_12_0488c1d914.jpg", "icon": "zoom_out_map"}]}
     },
     "descriptionSection": {
       "title":"Ventajas de realizar prácticas profesionales",
       "textIcons":[
         {
-          "icon": "https://drive.google.com/uc?export=view&id=1T0zh7_wWn_U7vC8Ghb1OnvK9Vf_iw8RI",
+          "icon": "https://assets.staging.bedu.org/UANE/admisiones_trophy_742ca1d363.png",
           "name": "nuevascompetencias", 
           "text": "<b>Adquieres nuevas competencias:</b>\n\nEn la universidad conoces la teoría, pero en el mundo laboral adquieres conocimientos prácticos, destrezas y habilidades."
         },
         {
-          "icon": "https://drive.google.com/uc?export=view&id=1zMwTLnS12WxMDnzO7oUt1MhUZYKtaqIv",
+          "icon": "https://assets.staging.bedu.org/UANE/admisiones_schoolboy_at_a_desk_a4f2a3393a.png",
           "name": "buscarempleo", 
           "text": "<b>Aprendes a buscar trabajo:</b>\n\nBuscar prácticas profesionales sirve de entrenamiento para buscar empleo. Redactar un cv atractivo será una tarea más sencilla para ti."
         },
         {
-          "icon": "https://drive.google.com/uc?export=view&id=1oxx9Lwrg7_C5nnNGnqYIsU7Y4QmDbTgM",
+          "icon": "https://assets.staging.bedu.org/UANE/admisiones_graduation_cap_4920a7788f.png",
           "name": "hacercontactos", 
           "text": "<b>Hacer contactos:</b>\n\nLas prácticas te permitirán establecer contactos con profesionales del sector y pueden ser una excelente carta de recomendación."
         },
         {
-          "icon": "https://drive.google.com/uc?export=view&id=1rJEHj6oYdFn3DI0k8-AJyKJEwPZ8vlxk",
+          "icon": "https://assets.staging.bedu.org/UANE/admisiones_crowd_6a442c00ee.png",
           "name": "conseguirempleto", 
           "text": "<b>Posibilidad de conseguir un empleo:</b>\n\nLas prácticas te permitirán establecer contactos con profesionales del sector y pueden ser una excelente carta de recomendación."
         },
         {
-          "icon": "https://drive.google.com/uc?export=view&id=1rJEHj6oYdFn3DI0k8-AJyKJEwPZ8vlxk",
+          "icon": "https://assets.staging.bedu.org/UANE/admisiones_crowd_6a442c00ee.png",
           "name": "mejorarcurriculim", 
           "text": "<b>Mejorar  el currículum:</b>\n\nLa realización de prácticas permite ampliar tu CV y demuestra tu interés por incorporarte al mundo laboral."
         }
@@ -160,15 +160,15 @@
       "image": {
         "desk": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=1NquBLD5HwafKLfWpn8J8fYBcCLdxh9mH"
+          "src": "https://assets.staging.bedu.org/UANE/conexion_practicas_profesionales_1_desk_50a58df8b3.jpg"
         },
         "tablet": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=1OhAFE6UMrVu7P-b1C6h59XODA31K4lcA"
+          "src": "https://assets.staging.bedu.org/UANE/conexion_practicas_profesionales_1_b391eb8f1d.jpg"
         },
         "mobile": {
           "alt": "imagen",
-          "src": "https://drive.google.com/uc?export=view&id=10fxtqvc-Dg0XvMAyFAzslPn0_rdVwGju"
+          "src": "https://assets.staging.bedu.org/UANE/conexion_practicas_profesionales_1_movil_a9307563bc.jpg"
         }
       }
     }


### PR DESCRIPTION
## Issue
 - Migrate images of "conexión educativa" page from drive to S3 bucket

## Solution
 - [feat: Conexion educativa page images migrated](https://github.com/techlottus/portalverse-uane/pull/104/commits/72430950de31294e39721c9ca5988b147efbd828)

## Testing
 - Go to `/nosotros/conexion-educativa`
 - See and compare images with [UANE](https://uane.edu.mx/nosotros/conexion-educativa) website
 - Keep rocking 🔥 