### PR TITLE
[DEV-5231] Migrate "contactanos" page images

### DIFF
--- a/config/faq.json
+++ b/config/faq.json
@@ -133,8 +133,8 @@
       "bottom": false,
       "left": false,
       "urlImage": {
-        "mobile": "https://drive.google.com/uc?export=view&id=18yIHL-H5UazsvIqib9qLInFgda41Eaqz",
-        "desktop": "https://drive.google.com/uc?export=view&id=1-oMRKt_jawT7t2F8zEybhaEIdlz0d89W"
+        "mobile": "https://assets.staging.bedu.org/UANE/Faq_Preguntas_Frecuentes_03_movil_0bc064842f.jpg",
+        "desktop": "https://assets.staging.bedu.org/UANE/Faq_Preguntas_Frecuentes_Mesa_de_trabajo_1_desk_55ec6f1737.jpg"
       },
       "overlay": "black",
       "height": "212px",

--- a/config/ponte-en-contacto.json
+++ b/config/ponte-en-contacto.json
@@ -58,9 +58,9 @@
     ],
     "banner": {
       "image": {
-        "desktop": "https://drive.google.com/uc?export=view&id=1Y_edCTwyeAXRGkcjqf5V2S8QEyVYaENW",
-        "mobile": "https://drive.google.com/uc?export=view&id=1PZURny8POJsMYHamJycNKgM3LmxoMUiK",
-        "tablet": "https://drive.google.com/uc?export=view&id=1TpgDT_hQIJ0hew0WPp40M21oURKnD9B_"
+        "desktop": "https://assets.staging.bedu.org/UANE/admisiones_internacional_desk_01a44424b3.jpg",
+        "mobile": "https://assets.staging.bedu.org/UANE/admisiones_Internacional_movil_6dbe0793b5.jpg",
+        "tablet": "https://assets.staging.bedu.org/UANE/admisiones_Internacional_tablet_40f0dc67bc.jpg"
       },
       "title": "UANE Internacional",
       "subtitle": "Internacionalízate agrega experiencias internacionales a tu educación",


### PR DESCRIPTION
## Issue
 - Migrate images of "faq" and "contactanos" pages from drive to S3 bucket

## Solution
 - [feat: ponte en contacto page images migrated](https://github.com/techlottus/portalverse-uane/pull/106/commits/9af30c61b01bdc2dc8b3b4e22e898ae9b9af7462)
 - [feat: faq page images migrated](https://github.com/techlottus/portalverse-uane/pull/106/commits/ab6e67aba59daf6cb8edd6d618d8870b7af7cb49)

## Testing
 - Go to `/contactanos`
 - See and compare images with [UANE](https://uane.edu.mx/contactanos) website
 - Go to `/contactanos/faq/general`
 - See and compare images with [UANE](https://uane.edu.mx/contactanos/faq/general) website
 - Keep rocking 🔥 