### PR TITLE
[DEV-5233] Migrate "egresados talento" page images

### DIFF
--- a/config/egresados-talento.json
+++ b/config/egresados-talento.json
@@ -12,7 +12,7 @@
     "experiencias": {
       "cards": [
         { 
-          "image": "https://drive.google.com/uc?export=view&id=1aUcuNe6I1zMp2-gYwbK7wO9FFTINPQ-T",
+          "image": "https://assets.staging.bedu.org/UANE/egresados_talento_Noe_Silva_edcefd0379.jpg",
           "subtitle": "DISEÑO GRÁFICO",
           "title": "Noé Silva",
           "text": "Noé ha logrado dejar huella con su trabajo en todo el país. Gracias a su único estilo, desde la imagen de una edición especial de la cerveza Indio, hasta el diseño del Quetzalcoatl de la imagen conmemorativa del aniversario de la independencia de México en 2021.",
@@ -32,7 +32,7 @@
           "video": "GMtcxjuvBHc"
         },
         { 
-          "image": "https://drive.google.com/uc?export=view&id=1lsuR-ejEiIq7GaFf5V3pHJ3zkIY6tlt8",
+          "image": "https://assets.staging.bedu.org/UANE/egresados_talento_Martha_Rodriguez_09a072422a.jpg",
           "subtitle": "RECURSOS HUMANOS",
           "title": "Martha Rodríguez",
           "text": "Después de concluir su Licenciatura, Martha continúa su crecimiento académico y profesional con una Maestría en Administración y Liderazgo en UANE. Hoy se desempeña como Gerente Administrativa.",
@@ -52,7 +52,7 @@
           "video": "RRd5gA6AVDY"
         },
         { 
-          "image": "https://drive.google.com/uc?export=view&id=1aMNri-Z6QO84SDIlX_LnlYW3goXelTXy",
+          "image": "https://assets.staging.bedu.org/UANE/egresados_Nidia_Orozco_539131e76b.jpg",
           "subtitle": "COMUNICACIÓN",
           "title": "Nidia Orozco",
           "text": "Nidia se consolidó en los medios de comunicación en Piedras Negras Coahuila, pero continúo su formación y hoy tiene su propio negocio.",
@@ -72,7 +72,7 @@
           "video": "rDfCvp0UrKg"
         },
         { 
-          "image": "https://drive.google.com/uc?export=view&id=1Dgn8f02hCN5rU7xsGQKG64BUlaNgatAT",
+          "image": "https://assets.staging.bedu.org/UANE/egresados_talento_Luis_Cruz_Brito_53b4427de0.jpg",
           "subtitle": "MERCADOTECNIA INTERNACIONAL",
           "title": "Luis Cruz Brito",
           "text": "Conoce la trayectoria de Luis quien hoy se desempeña como Gerente General Regional de Televisa Piedras Negras, Coahuila.",
@@ -92,7 +92,7 @@
           "video": "0bq-GyBddBo"
         },
         { 
-          "image": "https://drive.google.com/uc?export=view&id=1VzrgljQOc90V6KMGAG6SBNtX4iwYYqR1",
+          "image": "https://assets.staging.bedu.org/UANE/egresados_talento_Angel_Trevino_74b65cf3fb.jpg",
           "subtitle": "DISEÑO GRÁFICO",
           "title": "Ángel Treviño",
           "text": "Gracias a su excepcional trabajo como diseñador, Ángel ha logrado trabajar para artistas de alto nivel como Shakira o su más reciente colaboración con Gloria Trevi.",
@@ -112,7 +112,7 @@
           "video": "JSlK3lrUYY8"
         },
         { 
-          "image": "https://drive.google.com/uc?export=view&id=1od1pDMWv3auv2Vt2XTjlqSQl2EyYFcI7",
+          "image": "https://assets.staging.bedu.org/UANE/egresados_talento_FIDENCIO_GONZALEZ_487cc8d58a.jpg",
           "subtitle": "PSICOLOGÍA",
           "title": "FIDENCIO GONZÁLEZ",
           "text": "Ganador de la medalla de oro de los Juegos Panamericanos de Lima en 2019, Fidencio es Atleta de la Selección Mexicana de Tiro Deportivo y nos cuenta su paso por UANE Monterrey.",
@@ -136,8 +136,8 @@
     "aplica": {
       "banner":{
         "image": {
-          "desktop": "https://drive.google.com/uc?export=view&id=1bAZaQJAenCjvL_3Yw2Mj_50G3h-tB3gV",
-          "mobile": "https://drive.google.com/uc?export=view&id=1wSC-z_Mzco940OwZ1jKjqnv9c0wTUPx9"
+          "desktop": "https://assets.staging.bedu.org/UANE/egresados_talento_Quieres_postularte_01_desk_afb87452f2.jpg",
+          "mobile": "https://assets.staging.bedu.org/UANE/egresados_talento_Quieres_postularte_03_movil_35615e62c9.jpg"
         },
         "title": "¿Quieres postularte?",
         "subtitle": "",


### PR DESCRIPTION
## Issue
 - Migrate images of "faq" and "egresados talento" pages from drive to S3 bucket

## Solution
 - [feat: egresados talento page images migrated](https://github.com/techlottus/portalverse-uane/pull/107/commits/baa7420b5077dac04e71e428051acaaac52f6ed0)

## Testing
 - Go to `/egresados/talento`
 - See and compare images with [UANE](https://uane.edu.mx/egresados/talento) website
 - Keep rocking 🔥 