### PR TITLE
[DEV-5234] Migrate "oferta educativa" page images

### DIFF
--- a/config/oferta-educativa/oferta-educativa.json
+++ b/config/oferta-educativa/oferta-educativa.json
@@ -16,7 +16,7 @@
       "title": "Estudia en la modalidad que más te convenga",
       "modalities": [
         { 
-          "urlImage": "https://drive.google.com/uc?export=view&id=1LQ5gMlzjBHJRt_LD24p8rHzHxMb_bYzP",
+          "urlImage": "https://assets.staging.bedu.org/UANE/oferta_presencial_desk_4400f03556.jpg",
           "subtitle": "",
           "title": "Presencial",
           "text": "Asiste a clases y relaciónate en persona con profesores y alumnos en cualquiera de nuestros campus",
@@ -31,7 +31,7 @@
           "wrapper": true
         },
         { 
-          "urlImage": "https://drive.google.com/uc?export=view&id=1s_95yEEf8AtHRcvciNowBl5nIBwQZ7Ui",
+          "urlImage": "https://assets.staging.bedu.org/UANE/oferta_hibrido_desk_106621b465.jpg",
           "subtitle": "",
           "title": "Flex",
           "text": "Estudia en una modalidad híbrida, con clases remotas y presenciales",
@@ -46,7 +46,7 @@
           "wrapper": true
         },
         { 
-          "urlImage": "https://drive.google.com/uc?export=view&id=1_m_d-VlFYnVRS9wgVpi3d_tZY15ZOwK4",
+          "urlImage": "https://assets.staging.bedu.org/UANE/oferta_en_inea_desk_ff53f16ca3.jpg",
           "subtitle": "",
           "title": "En línea",
           "text": "Aprovecha tu tiempo al máximo y obtén tu título estudiando desde nuestra plataforma",
@@ -166,9 +166,9 @@
     "bannerTest":{
       "banner": {
         "image": {
-          "desktop": "https://drive.google.com/uc?export=view&id=1Y-NyCheOPilvlVa45pHQQ97mp-a-rQGy",
-          "mobile": "https://drive.google.com/uc?export=view&id=1XFnp_Ufc-rAqZxZ2KM60ogWyuS2vdOOi",
-          "tablet": "https://drive.google.com/uc?export=view&id=1x00pvwXu6r5KQjR5-zEuV3rbhsaboDFl"
+          "desktop": "https://assets.staging.bedu.org/UANE/oferta_dudas_desk_c3a242f117.jpg",
+          "mobile": "https://assets.staging.bedu.org/UANE/oferta_dudas_movil_21232e0033.jpg",
+          "tablet": "https://assets.staging.bedu.org/UANE/oferta_dudas_tablet_eab05d4b43.jpg"
         },
         "title": "¿Aún no decides qué estudiar?",
         "subtitle": "Te ayudamos a decidir qué rumbo profesional tomar",
@@ -195,9 +195,9 @@
     "bannerInternacionalizacion": {
       "banner": {
         "image": {
-          "desktop": "https://drive.google.com/uc?export=view&id=1Y_edCTwyeAXRGkcjqf5V2S8QEyVYaENW",
-          "mobile": "https://drive.google.com/uc?export=view&id=1PZURny8POJsMYHamJycNKgM3LmxoMUiK",
-          "tablet": "https://drive.google.com/uc?export=view&id=1TpgDT_hQIJ0hew0WPp40M21oURKnD9B_"
+          "desktop": "https://assets.staging.bedu.org/UANE/admisiones_internacional_desk_01a44424b3.jpg",
+          "mobile": "https://assets.staging.bedu.org/UANE/admisiones_Internacional_movil_6dbe0793b5.jpg",
+          "tablet": "https://assets.staging.bedu.org/UANE/admisiones_Internacional_tablet_40f0dc67bc.jpg"
         },
         "title": "UANE  Internacional",
         "subtitle": "Agrega experiencias internacionales a tus estudios",
@@ -243,9 +243,9 @@
     ],
     "bannerParche": {
       "image": {
-        "desktop": "https://drive.google.com/uc?export=view&id=1lmzq0OxTZmK_Ukzq0s0dDsyvUGKwrvFX",
-        "mobile": "https://drive.google.com/uc?export=view&id=1lmzq0OxTZmK_Ukzq0s0dDsyvUGKwrvFX",
-        "tablet": "https://drive.google.com/uc?export=view&id=1lmzq0OxTZmK_Ukzq0s0dDsyvUGKwrvFX"
+        "desktop": "https://assets.staging.bedu.org/UANE/oferta_banner_contacto_desk_1172d97c9c.jpg",
+        "mobile": "https://assets.staging.bedu.org/UANE/oferta_banner_contacto_desk_1172d97c9c.jpg",
+        "tablet": "https://assets.staging.bedu.org/UANE/oferta_banner_contacto_desk_1172d97c9c.jpg"
       },
       "title": " ¡La experiencia educativa que transforma!",
       "subtitle": "",

--- a/routes/Routes.ts
+++ b/routes/Routes.ts
@@ -8,8 +8,8 @@ const Routes: any = {
           title: "Bachillerato",
           promo: {
             urlImage: {
-              mobile: "https://drive.google.com/uc?export=view&id=1IZB-O4PNo9wwRDtweld_gpoRxzmv6WhX",
-              desktop: "https://drive.google.com/uc?export=view&id=1ooMLjk3zU7_8_A9W-NOdTOvjbGEw8qQW"
+              mobile: "https://assets.staging.bedu.org/UANE/oferta_bachillerato_movil_1f0d5cd934.jpg",
+              desktop: "https://assets.staging.bedu.org/UANE/oferta_bachillerato_desk_654176bdbd.jpg"
             },
             text: "",
             icon: "arrow_forward",
@@ -47,8 +47,8 @@ const Routes: any = {
           title: "Licenciaturas",
           promo: {
             urlImage: {
-              mobile: "https://drive.google.com/uc?export=view&id=1zl9VvR13Y1Tk0f-EfvkOzkHUZjQ2gPH_",
-              desktop: "https://drive.google.com/uc?export=view&id=1qB-SaPTknHUetoHA_e0CmcNQZxj2RZ2t"
+              mobile: "https://assets.staging.bedu.org/UANE/oferta_carreras_movil_b12eb60e44.jpg",
+              desktop: "https://assets.staging.bedu.org/UANE/oferta_carreras_desk_4ef261dd15.jpg"
             },
             text: "",
             icon: "arrow_forward",
@@ -115,8 +115,8 @@ const Routes: any = {
           title: "Especialidades",
           promo: {
             urlImage: {
-              mobile: "https://drive.google.com/uc?export=view&id=1jqW4m0V-UYJdCp2Ax0dqLxf04ansooLB",
-              desktop: "https://drive.google.com/uc?export=view&id=1lksUFh99fwx12CS5NDhSzzOwqjE2nBCQ"
+              mobile: "https://assets.staging.bedu.org/UANE/oferta_especialidades_movil_732aee5340.jpg",
+              desktop: "https://assets.staging.bedu.org/UANE/oferta_especialidades_desk_b96619eea0.jpg"
             },
             text: "",
             icon: "arrow_forward",
@@ -159,8 +159,8 @@ const Routes: any = {
           title: "Maestrías",
           promo: {
             urlImage: {
-              mobile: "https://drive.google.com/uc?export=view&id=1Y7pu9KD4hCZOM5MCQqYUf-cTkm6FjAxu",
-              desktop: "https://drive.google.com/uc?export=view&id=19gyvlX5gfDtt2QeQ5pnc66BAgtV9X5ng"
+              mobile: "https://assets.staging.bedu.org/UANE/oferta_maestrias_movil_1b1ed5735a.jpg",
+              desktop: "https://assets.staging.bedu.org/UANE/oferta_maestrias_desk_fd2e5b8460.jpg"
             },
             text: "",
             icon: "arrow_forward",
@@ -221,8 +221,8 @@ const Routes: any = {
           title: "Doctorado",
           promo: {
             urlImage: {
-              mobile: "https://drive.google.com/uc?export=view&id=1Hkdd9ScYfqlaS3D0wXntZ87PKJyFRXMG",
-              desktop: "https://drive.google.com/uc?export=view&id=1A-V4fwz_65l2Jrt20GxUOb22qshS7hqu"
+              mobile: "https://assets.staging.bedu.org/UANE/oferta_doctorados_movil_247423d2d0.jpg",
+              desktop: "https://assets.staging.bedu.org/UANE/oferta_doctorados_desk_e6f5d1e1ac.jpg"
             },
             text: "",
             icon: "arrow_forward",
@@ -261,8 +261,8 @@ const Routes: any = {
         title: "Extensión Universitaria",
         promo: {
           urlImage: {
-            mobile: "https://drive.google.com/uc?export=view&id=1A4Xz8N7VdVR7qOFR5TtzerX1Qek2qgMu",
-            desktop: "https://drive.google.com/uc?export=view&id=19Oe9R_hCPk8oY2t37VFiIHeZvWwUw3HL"
+            mobile: "https://assets.staging.bedu.org/UANE/oferta_educacion_continua_movil_1c7642bed7.jpg",
+            desktop: "https://assets.staging.bedu.org/UANE/oferta_educacion_continua_desk_a06f62f5fa.jpg"
           },
           text: "",
           icon: "arrow_forward",


### PR DESCRIPTION
## Issue
 - Migrate images of "oferta educativa" page from drive to S3

## Solution
 - [feat: oferta educativa page images migrated](https://github.com/techlottus/portalverse-uane/commit/1e36d906bb68d6a2cb0ddc2a0993dd733545944d)

## Testing
 - Go to `/oferta-educativa`
 - See and compare images with [UANE](https://uane.edu.mx/oferta-educativa) website
 - Keep rocking 🔥 