### PR TITLE
[DEV-5376] Migrate Banner numeralia component

### DIFF
--- a/old-components/BannerNumeralia/BannerNumeralia.tsx
+++ b/old-components/BannerNumeralia/BannerNumeralia.tsx
@@ -8,12 +8,12 @@ const BannerNumeralia: FC<any> = ({ data: { image, title, subtitle, statics }, c
     <Image classNames="w-d:aspect-7/2 w-t:aspect-2/1 w-p:aspect-3/4 absolute top-0 w-t:hidden w-p:hidden" classNamesImg="w-full h-full" src={image?.desktop} alt="imagen" />
     <Image classNames="w-d:aspect-7/2 w-t:aspect-2/1 w-p:aspect-3/4 absolute top-0 w-d:hidden w-p:hidden" classNamesImg="w-full h-full" src={image?.tablet} alt="imagen" />
     <Image classNames="w-d:aspect-7/2 w-t:aspect-2/1 w-p:aspect-3/4 absolute top-0 w-d:hidden w-t:hidden" classNamesImg="w-full h-full" src={image?.mobile} alt="imagen" />
-    <section className={cn("w-full numeralia flex flex-col justify-center w-p:justify-start px-6 py-12 w-p:py-6 w-t:h-[379px] w-p:h-full text-white absolute gap-6", classNames)}>
-      <h1 className="font-Poppins font-bold w-d:leading-15 w-t:leading-7.5 w-p:leading-7.5 w-d:text-13 w-t:text-6 w-p:text-6">{ title }</h1>
-      <h3 className="font-Nunito font-normal w-d:leading-5 w-t:leading-[17.5px] w-p:leading-[17.5px] w-d:text-base w-t:text-3.5 w-p:text-3.5">{ subtitle }</h3>
-      <div className="w-d:flex w-t:flex w-p:grid w-p:grid-cols-2 gap-1 w-p:gap-3">
+    <section className={cn("w-full numeralia flex flex-col justify-center w-p:justify-start px-6 w-d:py-8 w-t:py-12 w-p:py-8 w-p:h-auto text-white absolute gap-6", classNames)}>
+      <h1 className="font-Poppins font-bold w-d:leading-13 w-t:leading-7.5 w-p:leading-7.5 w-d:text-13 w-t:text-8.5 w-p:text-7.5">{ title }</h1>
+      <h3 className="font-Nunito font-bold w-d:text-10 w-t:text-6 w-p:text-6 w-d:leading-12.5 w-t:leading-[17.5px] w-p:leading-[17.5px]"><b>{ subtitle }</b></h3>
+      <div className="w-d:flex w-t:flex w-p:grid w-p:grid-cols-2 gap-4 w-p:gap-3">
         {
-          statics.map((item:any, i:number) => <section className="w-[144px]" key={`section-numbers-${i}`}>
+          statics?.map((item:any, i:number) => <section className={cn("max-w-[281px]", "w-p:mt-6")} key={`section-numbers-${i}`}>
               <NumbersPortalverse data={item}/>
             </section>)
         }


### PR DESCRIPTION
## Issue
- Migrate BannerNumeralia component from UTEG to that repo

## Solution
- [feat: BannerNumeralia component migrated](https://github.com/techlottus/portalverse-uane/commit/65b56920ac5fc768921ce8d69f5437794703a90d)

## Testing
- Go to `/egresados`
- Watch the Banner, change the size of the browser and check that the text does not go outside the banner
![image](https://github.com/techlottus/portalverse-uane/assets/62124025/02d52f9c-837b-48c3-9c55-73f9c95e32da)
- Keep rocking 🔥 