### PR TITLE
[DEV-5681] Fix bold text

### DIFF
--- a/old-components/Editor/Editor.scss
+++ b/old-components/Editor/Editor.scss
@@ -1,5 +1,27 @@
+//Font sizes are based on Strapi editor styles
 #editor {
   * {
     @apply font-Nunito-Sans font-normal;
+  }
+  b {
+    @apply font-bold;
+  }
+  h1 {
+    @apply font-bold text-10;
+  }
+  h2 {
+    @apply font-bold text-[1.5em];
+  }
+  h3 {
+    @apply font-bold text-[1.17rem];
+  }
+  h4 {
+    @apply font-bold text-[1em];
+  }
+  h5 {
+    @apply font-bold text-[0.83em];
+  }
+  h6 {
+    @apply font-bold text-[0.67em];
   }
 }


### PR DESCRIPTION
## Issue
- Make sure of the "b" tag works in the text blog section/page

## Solution
- [feat: blog styles fixed](https://github.com/techlottus/portalverse-uane/commit/6375b5d9054a672de62b153685e5bf40e3b08a56)

## Testing
- Go to `/voz-uane/blog/como-utilizar-data-science-para-mejorar-la-experiencia-del-cliente`
- Watch the page and make sure of the "b" tag and the other rich text tags works
![image](https://github.com/techlottus/portalverse-uane/assets/62124025/fb0f503b-860c-4173-af11-d7add7f6947e)
