### PR TITLE
Fix: add optional chaining on isValidPath

### DIFF
--- a/utils/routes.ts
+++ b/utils/routes.ts
@@ -1,5 +1,5 @@
 export const isValidPath = (path: string) => {
-  return !!path.trim() && !path?.includes("//") && !path?.includes(" ");
+  return !!path?.trim() && !path?.includes("//") && !path?.includes(" ");
 };
 
 /**


### PR DESCRIPTION
## Issue
Items in Strapi's `page` Collection Type without a slug are triggering a build-time error due to a missing optional chaining operator.