### PR TITLE
[DEV-5833] PromoLink component migration

### DIFF
--- a/components/sections/PromoLinkList.tsx
+++ b/components/sections/PromoLinkList.tsx
@@ -1,0 +1,72 @@
+import Link from "next/link";
+import Container from "@/layouts/Container.layout";
+import PromoLink from "@/old-components/PromoLink";
+import type { FC } from "react";
+import type { PromoLinkListSection } from "@/utils/strapi/sections/PromoLinkList";
+
+const PromoLinkList: FC<PromoLinkListSection> = (props: PromoLinkListSection) => {
+  const { title, promoLinks } = props;
+
+  return (
+    <section>
+      <Container>
+        <div className="flex flex-col space-y-6">
+          {
+            title
+              ? <h3 className="font-Poppins text-10 font-bold leading-[125%] w-t:text-8.5 w-p:text-6">{title}</h3>
+              : null
+          }
+          {
+            promoLinks?.length > 0 ?
+              <div className="w-d:col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-4 w-t:grid-cols-2 w-p:grid-cols-1 w-d:mb-12 w-p:mb-6 gap-6">
+                {
+                  promoLinks?.map((promoLink, index) => {
+                    const {
+                      text,
+                      link,
+                      color
+                    } = promoLink;
+
+                    return (
+                      promoLink?.text ?
+                        promoLink?.link ?
+                          <Link key={index} href={link || "#"}>
+                            <PromoLink
+                              //@ts-ignore
+                              data={{
+                                text,
+                                isShadowColor: true,
+                                enable: true,
+                                nobackground: true,
+                                height: "100px"
+                              }}
+                              shadowColor={color ? color : null}
+                            />
+                          </Link>
+                          :
+                          <PromoLink
+                            key={index}
+                            //@ts-ignore
+                            data={{
+                              text,
+                              isShadowColor: true,
+                              enable: true,
+                              nobackground: true,
+                              height: "100px"
+                            }}
+                            shadowColor={color ? color : null}
+                          />
+                        : null
+                    )
+                  })
+                }
+              </div>
+              : null
+          }
+        </div>
+      </Container>
+    </section>
+  );
+};
+
+export default PromoLinkList;

--- a/old-components/PromoLink.tsx
+++ b/old-components/PromoLink.tsx
@@ -2,7 +2,7 @@ import { createRef, FC, memo, useEffect } from "react"
 import cn from "classnames"
 import { PromoLinkData } from "@/types/Promolink.types"
 
-const PromoLink: FC<PromoLinkData> = memo(({ data, classNames, typeShadowColor="",  onClick } : PromoLinkData) => {
+const PromoLink: FC<PromoLinkData> = memo(({ data, classNames, typeShadowColor = "", shadowColor = null, onClick }: PromoLinkData) => {
   const promoLinkPortalverseRef = createRef();
 
   useEffect(() => {
@@ -36,6 +36,10 @@ const PromoLink: FC<PromoLinkData> = memo(({ data, classNames, typeShadowColor="
     }
   }, [onClick]);// eslint-disable-line react-hooks/exhaustive-deps
 
+  const customStyles = {
+    boxShadow: `-5px 6px 0px 0px ${shadowColor}`
+  };
+
   return <>
     <div className={cn(classNames, {
       "shadow-pastelBlueShadowLeft rounded": data.isShadowColor === true && typeShadowColor === 'blue-pastel-left',
@@ -47,8 +51,10 @@ const PromoLink: FC<PromoLinkData> = memo(({ data, classNames, typeShadowColor="
       "shadow-pastelYellowShadowRight rounded": data.isShadowColor === true && typeShadowColor === 'yellow-pastel-right',
       "shadow-pastelRedShadowRight rounded": data.isShadowColor === true && typeShadowColor === 'red-pastel-right',
       "shadow-pastelGrayShadowRight rounded": data.isShadowColor === true && typeShadowColor === 'gray-pastel-right',
-      "shadow-blueShadowRight rounded": data.isShadowColor === true && typeShadowColor === 'blue-right'
-      })}>
+      "shadow-blueShadowRight rounded": data.isShadowColor === true && typeShadowColor === 'blue-right',
+      "rounded": shadowColor && data?.isShadowColor})}
+      style={shadowColor ? customStyles : {}}
+    >
       <lottus-promo-link-portalverse ref={promoLinkPortalverseRef}></lottus-promo-link-portalverse>
     </div>
   </>

--- a/utils/Renderers.tsx
+++ b/utils/Renderers.tsx
@@ -11,6 +11,7 @@ import Paragraph from "@/components/Paragraph";
 import PodcastList from "@/components/sections/PodcastList";
 import RichTextImage from "@/components/sections/RichTextImage";
 import TextContent from "@/components/sections/TextContent";
+import PromoLinkList from "@/components/sections/PromoLinkList";
 import type { FC } from "react";
 
 type Renderer = {
@@ -31,6 +32,7 @@ const defaultRenderers: Renderer = {
   ComponentSectionsRichTextImage: RichTextImage,
   ComponentSectionsTextContent: TextContent,
   ComponentSectionsPodcastList: PodcastList,
+  ComponentSectionsPromoLinkList: PromoLinkList,
 };
 
 export default defaultRenderers;

--- a/utils/getPagesData.ts
+++ b/utils/getPagesData.ts
@@ -18,7 +18,7 @@ const getPagesData = async () => {
 
 const PAGES = `
 query Pages {
-  pages {
+  pages(pagination: {start: 0, limit: -1}) {
     data {
       id
       attributes {

--- a/utils/strapi/queries.ts
+++ b/utils/strapi/queries.ts
@@ -10,6 +10,7 @@ import { LIST_CONFIG } from "@/utils/strapi/sections/Listconfig";
 import { PODCAST_LIST } from "@/utils/strapi/sections/PodcastList";
 import { RICH_TEXT_IMAGE } from "@/utils/strapi/sections/RichTextImage";
 import { TEXT_CONTENT } from "@/utils/strapi/sections/TextContent";
+import { PROMO_LINK_LIST } from "@/utils/strapi/sections/PromoLinkList";
 import type { AlertSection } from "@/utils/strapi/sections/Alert";
 import type { BannerSection } from "@/utils/strapi/sections/Banner";
 import type { BlogPostsPodcastSection } from "@/utils/strapi/sections/BlogPostsPodcast";
@@ -22,6 +23,7 @@ import type { ListconfigSection } from "@/utils/strapi/sections/Listconfig";
 import type { PodcastListSection } from "@/utils/strapi/sections/PodcastList";
 import type { RichTextImageSection } from "@/utils/strapi/sections/RichTextImage";
 import type { TextContentSection } from "@/utils/strapi/sections/TextContent";
+import type { PromoLinkListSection } from "@/utils/strapi/sections/PromoLinkList";
 
 export type ComponentSection =
   | AlertSection
@@ -36,6 +38,7 @@ export type ComponentSection =
   | ListconfigSection
   | PodcastListSection
   | HeroSliderSection
+  | PromoLinkListSection
 
 export const SECTIONS = `
   ${ALERT}
@@ -54,4 +57,5 @@ export const SECTIONS = `
   ${LIST_CONFIG}
   ${PODCAST_LIST}
   ${HERO_SLIDER}
+  ${PROMO_LINK_LIST}
 `;

--- a/utils/strapi/sections/PromoLinkList.ts
+++ b/utils/strapi/sections/PromoLinkList.ts
@@ -1,0 +1,24 @@
+type PromoLink = {
+  text: string;
+  link: string;
+  color: string;
+};
+
+export type PromoLinkListSection = {
+  type: "ComponentSectionsPromoLinkList";
+  title: string;
+  promoLinks: Array<PromoLink>;
+};
+
+export const PROMO_LINK_LIST = `
+...on ComponentSectionsPromoLinkList {
+  id,
+  title,
+  promoLinks {
+    id,
+    text,
+    link,
+    color
+  }
+}
+`;


### PR DESCRIPTION
## Issue
Corresponding migration of PromoLinkList component as implemented in [UTEG project #5829](https://github.com/techlottus/portalverse/pull/160).

## Solution
- [X] Updated PromoLink component 84ade94.
- [X] Created Promo link list types 33a0875.
- [X] Created promo link list renderer 57b7b3d.
- [X] Updated queries with promo link list a36f8d1.
- [X] Added promo link list renderer to the list 30b98de.
- [X] Updated get pages data query with pagination aab9300.

## Testing
Repeat the same steps as described in the related URL in the PR's issue.