### PR TITLE
[DEV-5851] CardList component migration

### DIFF
--- a/components/index.scss
+++ b/components/index.scss
@@ -1,1 +1,2 @@
 // TODO: Add imports for new components stylesheets. For reference, see "@/old-components/index.scss"
+@import '@/components/sections/CardList/styles.scss';

--- a/components/sections/CardList/index.tsx
+++ b/components/sections/CardList/index.tsx
@@ -1,0 +1,72 @@
+import Container from "@/layouts/Container.layout";
+import CardWebsite from "@/old-components/CardWebsite";
+import type { FC } from "react";
+import type { CardListSection } from "@/utils/strapi/sections/CardList";
+import parseEditorRawData from "@/utils/parseEditorRawData";
+
+const CardList: FC<CardListSection> = (props: CardListSection) => {
+  const {
+    title,
+    cards,
+  } = props;
+
+  return (
+    <section>
+      <Container>
+        <div className="flex flex-col space-y-6">
+          {
+            title
+              ? <h3 className="font-Poppins text-10 font-bold leading-[125%] w-t:text-8.5 w-p:text-6">{title}</h3>
+              : null
+          }
+          {
+            cards?.length > 0 ?
+              <div className="col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-3 gap-6 w-t:grid-cols-2 w-p:grid-cols-1 w-d:mb-12 w-p:mb-6">
+                {
+                  cards?.map((card, index) => {
+                    const urlImage = card?.image?.data?.attributes?.url;
+                    const cardContent = parseEditorRawData(card?.content);
+                    const {
+                      linkText,
+                      linkUrl
+                    } = card;
+
+                    return (
+                      <div key={index} className="card">
+                          <CardWebsite
+                            //@ts-ignore
+                            data={{
+                              ...card,
+                              type: "vertical",
+                              urlImage,
+                              text: cardContent,
+                              wrapper: true,
+                              //@ts-ignore
+                              linkIcon: linkText ? {
+                                text: linkText,
+                                disabled: !linkUrl,
+                                size: "medium"
+                              } : null,
+                              link: true,
+                            }}
+                            onClick={() => {
+                              if (!!linkUrl) {
+                                return window?.open(linkUrl, "_self")
+                              }
+                              return null
+                            }}
+                          />
+                      </div>
+                    )
+                  })
+                }
+              </div>
+              : null
+          }
+        </div>
+      </Container>
+    </section>
+  );
+};
+
+export default CardList;

--- a/components/sections/CardList/styles.scss
+++ b/components/sections/CardList/styles.scss
@@ -12,8 +12,5 @@
         }
       }
     }
-    .link-content {
-      color: #000;
-    }
   }
 }

--- a/components/sections/CardList/styles.scss
+++ b/components/sections/CardList/styles.scss
@@ -1,0 +1,19 @@
+.card {
+  lottus-link {
+    .link-content.-disabled {
+      color: #cdcdcd;
+      cursor: not-allowed;
+
+      &:hover {
+        .text {
+          cursor: not-allowed;
+          text-decoration: none;
+          user-select: none;
+        }
+      }
+    }
+    .link-content {
+      color: #000;
+    }
+  }
+}

--- a/utils/Renderers.tsx
+++ b/utils/Renderers.tsx
@@ -1,6 +1,7 @@
 import Alert from "@/components/sections/Alert";
 import Banner from "@/components/sections/Banner";
 import BlogPostsPodcast from "@/components/sections/BlogPostsPodcast";
+import CardList from "@/components/sections/CardList";
 import ContactTargetList from "@/components/sections/ContactTargetList";
 import FAQ from "@/components/sections/FAQ";
 import HeroSlider from "@/components/sections/HeroSlider";
@@ -9,9 +10,9 @@ import LinkList from "@/components/sections/LinkList";
 import Listconfig from "@/components/sections/Listconfig";
 import Paragraph from "@/components/Paragraph";
 import PodcastList from "@/components/sections/PodcastList";
+import PromoLinkList from "@/components/sections/PromoLinkList";
 import RichTextImage from "@/components/sections/RichTextImage";
 import TextContent from "@/components/sections/TextContent";
-import PromoLinkList from "@/components/sections/PromoLinkList";
 import type { FC } from "react";
 
 type Renderer = {
@@ -23,6 +24,7 @@ const defaultRenderers: Renderer = {
   ComponentSectionsAlert: Alert,
   ComponentSectionsBanner: Banner,
   ComponentSectionsBlogPostsPodcast: BlogPostsPodcast,
+  ComponentSectionsCardList: CardList,
   ComponentSectionsContactTargetList: ContactTargetList,
   ComponentSectionsFaqSection: FAQ,
   ComponentSectionsHeroSlider: HeroSlider,

--- a/utils/strapi/queries.ts
+++ b/utils/strapi/queries.ts
@@ -1,6 +1,7 @@
 import { ALERT } from "@/utils/strapi/sections/Alert";
 import { BANNER } from "@/utils/strapi/sections/Banner";
 import { BLOG_POSTS_PODCAST } from "@/utils/strapi/sections/BlogPostsPodcast";
+import { CARD_LIST } from "@/utils/strapi/sections/CardList";
 import { CONTACT_TARGET_LIST } from "@/utils/strapi/sections/ContactTargetList";
 import { FAQ_SECTION } from "@/utils/strapi/sections/FAQ";
 import { HERO_SLIDER } from "@/utils/strapi/sections/HeroSlider";
@@ -14,6 +15,7 @@ import { PROMO_LINK_LIST } from "@/utils/strapi/sections/PromoLinkList";
 import type { AlertSection } from "@/utils/strapi/sections/Alert";
 import type { BannerSection } from "@/utils/strapi/sections/Banner";
 import type { BlogPostsPodcastSection } from "@/utils/strapi/sections/BlogPostsPodcast";
+import type { CardListSection } from "@/utils/strapi/sections/CardList";
 import type { ContactTargetListSection } from "@/utils/strapi/sections/ContactTargetList";
 import type { FAQSection } from "@/utils/strapi/sections/FAQ";
 import type { HeroSliderSection } from "@/utils/strapi/sections/HeroSlider";
@@ -28,6 +30,7 @@ import type { PromoLinkListSection } from "@/utils/strapi/sections/PromoLinkList
 export type ComponentSection =
   | AlertSection
   | BannerSection
+  | CardListSection
   | ContactTargetListSection
   | FAQSection
   | LeaderboardSection
@@ -44,6 +47,7 @@ export const SECTIONS = `
   ${ALERT}
   ${BANNER}
   ${BLOG_POSTS_PODCAST}
+  ${CARD_LIST} 
   ${CONTACT_TARGET_LIST}
   ${FAQ_SECTION}
   ${HERO_SLIDER}

--- a/utils/strapi/sections/CardList.ts
+++ b/utils/strapi/sections/CardList.ts
@@ -1,0 +1,43 @@
+import type { StrapiImage } from "@/types/strapi/common";
+
+type Card = {
+  title: string;
+  subtitle: string;
+  type: string;
+  content: string;
+  linkText: string;
+  linkUrl: string;
+  image: StrapiImage;
+  imageAspectRatio: string;
+};
+
+export type CardListSection = {
+  type: "ComponentSectionsCardList",
+  title: string;
+  cards: Array<Card>;
+};
+
+export const CARD_LIST = `
+...on ComponentSectionsCardList {
+  id
+  title
+  cards {
+    id
+    title
+    subtitle
+    content
+    type
+    linkText
+    linkUrl
+    image {
+      data {
+        attributes {
+          url
+          alternativeText
+        }
+      }
+    }
+    imageAspectRatio
+  }
+}
+`;


### PR DESCRIPTION
## Issue
Corresponding migration of PromoLinkList component as implemented in [UTEG project #5830](https://github.com/techlottus/portalverse/pull/170).

## Solution
- [X] Created card ist types + query 73471a1.
- [X] Created card list component 7a3f1fe.
- [X] Implemented custom styles for CardWebsite link 230c045.
- [X] Added card list query to strapi queries a731e3c.
- [X] Added card list to renderers list bcf1c99.

## Testing
Repeat the same steps as described in the related URL in the PR's issue.