### PR TITLE
[DEV-5859] StatisticsCardList component migration

### DIFF
--- a/components/NumbersPortalverseWrapper.tsx
+++ b/components/NumbersPortalverseWrapper.tsx
@@ -1,6 +1,6 @@
 import NumbersPortalverse from "@/old-components/NumbersPortalverse/NumbersPortalverse";
 import { NumbersPortalverseData } from "@/types/NumbersPortalverse.types";
-import { Card } from "@/utils/strapi/sections/StatisticsCardList";
+import { StatisticsCard } from "@/utils/strapi/sections/StatisticsCardList";
 import { Replace } from "@/utils/typescript";
 
 const defaultCardNumberData = {
@@ -43,7 +43,7 @@ const formatData = (
 type NumbersPortalverseWrapper = Replace<
   NumbersPortalverseData,
   "data",
-  Card & { classNames?: string }
+  StatisticsCard & { classNames?: string }
 >;
 
 const NumbersPortalverseWrapper = (props: NumbersPortalverseWrapper) => {

--- a/components/sections/StatisticsCardList.tsx
+++ b/components/sections/StatisticsCardList.tsx
@@ -1,0 +1,37 @@
+import Container from "@/layouts/Container.layout";
+import NumbersPortalverseWrapper from "@/components/NumbersPortalverseWrapper";
+import type { StatisticsCardListSection } from "@/utils/strapi/sections/StatisticsCardList";
+
+const StatisticsCardList = (props: StatisticsCardListSection) => {
+  const { statisticsCards: cards } = props;
+
+  return (
+    <section>
+      <Container>
+        {
+          cards?.length > 0
+            ? <div
+                className="grid w-p:!grid-cols-1 w-t:!grid-cols-2 gap-6"
+                style={{ gridTemplateColumns: "repeat(4, minmax(0, 1fr))" }}
+              >
+                {
+                  cards?.map((card, i) => {
+                    return (
+                      <div key={i}>
+                        <NumbersPortalverseWrapper
+                          data={card}
+                          classNames="p-2 justify-center"
+                        />
+                      </div>
+                    );
+                  })
+                }
+              </div>
+            : null
+        }
+      </Container>
+    </section>
+  );
+};
+
+export default StatisticsCardList;

--- a/old-components/NumbersPortalverse/NumbersPortalverse.tsx
+++ b/old-components/NumbersPortalverse/NumbersPortalverse.tsx
@@ -15,8 +15,8 @@ const NumbersPortalverse: FC<NumbersPortalverseData> = memo(({data, classNames }
   const iconsClassNames = data?.iconClassNames;
 
   return <>
-    <div style={customStyles} className={cn("wrapperNumbers", classNames, {
-      "shadow-30 rounded-lg bg-white": data.boxShadow,
+    <div style={customStyles} className={cn("wrapperNumbers rounded-lg", classNames, {
+      "shadow-30 bg-white": data.boxShadow,
       "border border-[#CDCDCD]": data.bordered,
       "rounded-lg": !!data?.isShadowColor,
       "shadow-pastelBlueShadowLeft": data.isShadowColor === true && data.typeShadowColor === 'blue-pastel-left',

--- a/utils/Renderers.tsx
+++ b/utils/Renderers.tsx
@@ -13,6 +13,7 @@ import Paragraph from "@/components/Paragraph";
 import PodcastList from "@/components/sections/PodcastList";
 import PromoLinkList from "@/components/sections/PromoLinkList";
 import RichTextImage from "@/components/sections/RichTextImage";
+import StatisticsCardList from "@/components/sections/StatisticsCardList";
 import TextContent from "@/components/sections/TextContent";
 import type { FC } from "react";
 
@@ -36,6 +37,7 @@ const defaultRenderers: Renderer = {
   ComponentSectionsPodcastList: PodcastList,
   ComponentSectionsPromoLinkList: PromoLinkList,
   ComponentSectionsRichTextImage: RichTextImage,
+  ComponentSectionsStatisticsCardList: StatisticsCardList,
   ComponentSectionsTextContent: TextContent,
 };
 

--- a/utils/strapi/queries.ts
+++ b/utils/strapi/queries.ts
@@ -10,9 +10,10 @@ import { LINK_LIST } from "@/utils/strapi/sections/LinkList";
 import { LIST_CONFIG } from "@/utils/strapi/sections/Listconfig";
 import { OVERLAY_CARD_LIST } from "@/utils/strapi/sections/OverlayCardList";
 import { PODCAST_LIST } from "@/utils/strapi/sections/PodcastList";
-import { RICH_TEXT_IMAGE } from "@/utils/strapi/sections/RichTextImage";
-import { TEXT_CONTENT } from "@/utils/strapi/sections/TextContent";
 import { PROMO_LINK_LIST } from "@/utils/strapi/sections/PromoLinkList";
+import { RICH_TEXT_IMAGE } from "@/utils/strapi/sections/RichTextImage";
+import { STATISTICS_CARD_LIST } from "@/utils/strapi/sections/StatisticsCardList";
+import { TEXT_CONTENT } from "@/utils/strapi/sections/TextContent";
 import type { AlertSection } from "@/utils/strapi/sections/Alert";
 import type { BannerSection } from "@/utils/strapi/sections/Banner";
 import type { BlogPostsPodcastSection } from "@/utils/strapi/sections/BlogPostsPodcast";
@@ -23,10 +24,12 @@ import type { HeroSliderSection } from "@/utils/strapi/sections/HeroSlider";
 import type { LeaderboardSection } from "@/utils/strapi/sections/Leaderboard";
 import type { LinkListSection } from "@/utils/strapi/sections/LinkList";
 import type { ListconfigSection } from "@/utils/strapi/sections/Listconfig";
+import type { OverlayCardListSection } from "@/utils/strapi/sections/OverlayCardList";
 import type { PodcastListSection } from "@/utils/strapi/sections/PodcastList";
-import type { RichTextImageSection } from "@/utils/strapi/sections/RichTextImage";
-import type { TextContentSection } from "@/utils/strapi/sections/TextContent";
 import type { PromoLinkListSection } from "@/utils/strapi/sections/PromoLinkList";
+import type { RichTextImageSection } from "@/utils/strapi/sections/RichTextImage";
+import type { StatisticsCardListSection } from "@/utils/strapi/sections/StatisticsCardList";
+import type { TextContentSection } from "@/utils/strapi/sections/TextContent";
 
 export type ComponentSection =
   | AlertSection
@@ -38,11 +41,13 @@ export type ComponentSection =
   | HeroSliderSection
   | LeaderboardSection
   | LinkListSection
-  | TextContentSection
   | ListconfigSection
+  | OverlayCardListSection
   | PodcastListSection
-  | RichTextImageSection
   | PromoLinkListSection
+  | RichTextImageSection
+  | StatisticsCardListSection
+  | TextContentSection
 
 export const SECTIONS = `
   ${ALERT}
@@ -59,5 +64,6 @@ export const SECTIONS = `
   ${PODCAST_LIST}
   ${PROMO_LINK_LIST}
   ${RICH_TEXT_IMAGE}
+  ${STATISTICS_CARD_LIST}
   ${TEXT_CONTENT}
 `;

--- a/utils/strapi/sections/StatisticsCardList.ts
+++ b/utils/strapi/sections/StatisticsCardList.ts
@@ -1,28 +1,30 @@
-export type Card = {
+export type StatisticsCard = {
   title: string;
   body: string;
   maxNumber: number;
   prefix: string;
   suffix: string;
-  color: string;
   iconName: string;
+  color: string;
+  variant: "neutral" | "stroke" | "shadow";
 };
 
 export type StatisticsCardListSection = {
   type: "ComponentSectionsStatisticsCardList";
-  cards: Array<Card>;
+  statisticsCards: Array<StatisticsCard>;
 };
 
 export const STATISTICS_CARD_LIST = `
 ...on ComponentSectionsStatisticsCardList {
-  cards {
+  statisticsCards: cards {
     title
     body
     maxNumber
     prefix
     suffix
-    color
     iconName
+    color
+    variant
   }
 }
 `;


### PR DESCRIPTION
## Issue
Corresponding migration of StatisticsCardList component as implemented in [UTEG project #5844](https://github.com/techlottus/portalverse/pull/168).

## Solution
- [X] update StatisticsCardList section query e0933d8.
- [X] create StatisticsCardList section renderer component 9cb44fd.
- [X] update type import e79ac70.
- [X] update NumbersPortalverse styles 55a53df.
- [X] update Renderers & Queries dictionaries 670e61e.

## Testing
Repeat the same steps as described in the related URL in the PR's issue.