### PR TITLE
[DEV-5997] Render Level-specific Program Detail Page migration

### DIFF
--- a/components/DynamicProgramContent.tsx
+++ b/components/DynamicProgramContent.tsx
@@ -1,7 +1,26 @@
-const DynamicProgramContent = () => {
-  return (
-    <div>DynamicProgramContent</div>
-  )
+import { Fragment } from "react";
+import type { DynamicProgramDetailData } from "@/utils/pages";
+
+const DynamicProgramContent = (props: DynamicProgramDetailData) => {
+
+  const programAttributes = props?.program?.attributes;
+  const level = programAttributes?.level?.data?.attributes?.title;
+
+  const renderContent = () => {
+    switch(level) {
+      case "Educación Continua": {
+        return <h1>Agregar Renderer de Educación Continua</h1>
+      }
+      case "Bachillerato": {
+        return <h1>Agregar Renderer de Bachillerato</h1>
+      }
+      default: {
+        return <h1>Agregar Renderer de Nivel Superior</h1>
+      }
+    }
+  }
+
+  return <Fragment>{renderContent()}</Fragment>;
 };
 
 export default DynamicProgramContent;

--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -43,7 +43,7 @@ const Page = (props: PageProps) => {
       case "StaticContinuousEducationProgramDetail":
         return <StaticContEdProgramContent {...pageData} />;
       case "DynamicProgramDetail":
-        return <DynamicProgramContent />;
+        return <DynamicProgramContent {...pageData} />;
       default:
         return null;
     }
@@ -85,16 +85,18 @@ export async function getStaticPaths() {
 }
 
 // `getStaticPaths` requires using `getStaticProps`
-export async function getStaticProps(context: any) {
+export async function getStaticProps(context: any): Promise<{props: PageProps}> {
   const {
     params: { slug },
   } = context;
 
   const path = slug?.join("/");
   const pageType = await getPageType(path);
+
   switch (pageType) {
     case "programDetail": {
       const programDetailData = await getProgramDetailPageData(path);
+
       return {
         props: {
           page: { ...programDetailData },
@@ -105,7 +107,7 @@ export async function getStaticProps(context: any) {
     case "blogEntry": {
       return {
         props: {
-          page: {},
+          page: {} as any, // TODO
           breadcrumb: {},
         },
       };
@@ -124,10 +126,10 @@ export async function getStaticProps(context: any) {
     default: {
       return {
         props: {
-          page: {},
+          page: {} as any, // TODO
           breadcrumb: {},
         },
       };
     }
   }
-};
+}

--- a/utils/getProgramBySlug.ts
+++ b/utils/getProgramBySlug.ts
@@ -1,7 +1,19 @@
 import { fetchStrapiGraphQL } from "@/utils/getStrapi";
 import type { StrapiImage } from "@/types/strapi/common";
 
-type CurriculumsDetail = {
+/**
+ * These are the current program levels available in [UANE, UTEG] exactly as they appear in Salesforce.
+ * These strings must match exactly when registering program levels in Strapi's "Level" Collection Type.
+ */
+type ProgramLevel =
+  | "Bachillerato"
+  | "Licenciatura"
+  | "Maestría"
+  | "Doctorado"
+  | "Especialidad"
+  | "Educación Continua";
+
+type CurriculumDetail = {
   campus: {
     data: {
       attributes: {
@@ -31,22 +43,28 @@ type ProgramModalitiesDetail = {
   laborField: string;
   admissionRequirements: string;
   curriculumDescription: string;
-  curriculums: Array<CurriculumsDetail>
+  curriculums: Array<CurriculumDetail>
 }
 
 export type ProgramData = {
+  id: number;
   attributes: {
+    slug: string;
     name: string;
     description: string;
-    image: StrapiImage
-    programModalities: Array<ProgramModalitiesDetail>
+    image: StrapiImage;
+    detail: string;
+    programModalities: Array<ProgramModalitiesDetail>;
     level: {
       data: {
         attributes: {
-          title: string
+          title: ProgramLevel;
         }
       }
     }
+    price: number;
+    offerPrice: number;
+    priceDetail: string;
   }
 }
 
@@ -65,7 +83,9 @@ const PROGRAM_BY_SLUG = `
 query ProgramBySlug($slug: String!) {
   programs(filters: { slug: { eq: $slug } }) {
     data {
+      id
       attributes {
+        slug
         name
         description
         image {
@@ -76,6 +96,7 @@ query ProgramBySlug($slug: String!) {
             }
           }
         }
+        detail
         level {
           data {
             attributes {
@@ -83,6 +104,9 @@ query ProgramBySlug($slug: String!) {
             }
           }
         }
+        price
+        offerPrice
+        priceDetail
         programModalities {
           admissionProfile
           graduateProfile

--- a/utils/pages.ts
+++ b/utils/pages.ts
@@ -7,7 +7,9 @@ import getEducationalOfferingConfig from "@/utils/getEducationalOfferingConfig";
 import getPagesInfo from "@/utils/getPagesInfo";
 import getProgramsByLevel from "@/utils/getProgramsByLevel";
 import { isValidPath, normalizePath } from "@/utils/misc";
-import type { PageData, PageEntityResponse } from "@/utils/getPageDataById";
+import getProgramBySlug from "@/utils/getProgramBySlug";
+import type { PageEntityResponse } from "@/utils/getPageDataById";
+import type { ProgramData } from "@/utils/getProgramBySlug";
 
 type PageType = "programDetail" | "blogEntry" | "dynamic";
 
@@ -37,6 +39,11 @@ export const getPageType = async (path: string): Promise<PageType> => {
  * PAGE DATA FETCHING
  */
 
+export type DynamicProgramDetailData = {
+  program: ProgramData;
+  layout?: any;
+};
+
 export type ProgramDetailPage =
   | {
       type: "StaticProgramDetail";
@@ -48,25 +55,25 @@ export type ProgramDetailPage =
     }
   | {
       type: "DynamicProgramDetail";
-      data: PageData;
+      data: DynamicProgramDetailData
     };
 
 export const getPageDataBySlug = async (slug: string) => {
   const pagesInfo = await getPagesInfo();
-
+    
   const targetPage = pagesInfo?.find(
     (page) => normalizePath(page?.attributes?.slug) === normalizePath(slug)
   );
   const targetPageId = targetPage?.id;
 
   if (!targetPageId) throw new Error("Page ID Not Found");
-
+    
   const pageData = await getPageDataById({ id: targetPageId });
   return pageData?.page;
 };
 
 export const getProgramDetailPageData = async (path: string): Promise<ProgramDetailPage> => {
-  const pathSegments = path?.split("/");
+  const pathSegments = normalizePath(path)?.split("/");
   const levelSlug = pathSegments?.slice(pathSegments?.length - 2, pathSegments?.length - 1)?.[0];
   const programSlug = pathSegments?.slice(pathSegments?.length - 1, pathSegments?.length)?.[0];
 
@@ -113,15 +120,18 @@ export const getProgramDetailPageData = async (path: string): Promise<ProgramDet
 
     }
   } else {
+    const programData = await getProgramBySlug(programSlug);
 
     return {
       // TODO
       type: "DynamicProgramDetail",
-      data: {} as PageData,
+      data: {
+        program: { ...programData },
+      },
     };
-
+    
   }
-
+  
 }
 
 
@@ -144,7 +154,7 @@ export const getBlogEntryPagesPaths = async () => {
         ?.map((blogEntrySlug) => `${blogEntryParentSlug}/${blogEntrySlug}`)
         ?.filter(isValidPath)
     : [];
-
+  
   return blogEntriesPaths;
 }
 
@@ -154,7 +164,7 @@ export const getDynamicPagesPaths = async () => {
 
   // pages with an invalid path format are filtered out and won't be generated at build time
   const dynamicPagesPaths = pagesPaths?.filter(isValidPath);
-
+  
   return dynamicPagesPaths;
 }
 

--- a/utils/pages.ts
+++ b/utils/pages.ts
@@ -18,11 +18,11 @@ export const getPageType = async (path: string): Promise<PageType> => {
 
   const blogEntryPageData = await getBlogEntryPageData();
   const blogEntryParentSlug = normalizePath(blogEntryPageData?.data?.attributes?.slug);
-  const isBlogEntryPage = path?.includes(blogEntryParentSlug) && normalizedPath !== normalizePath(blogEntryParentSlug);
+  const isBlogEntryPage = path?.startsWith(`${blogEntryParentSlug}/`) && normalizedPath !== normalizePath(blogEntryParentSlug);
 
   const levelsConfig = await getEducationalOfferingConfig();
   const programDetailParentSlugs = levelsConfig?.map(levelConfig => normalizePath(levelConfig?.slug))
-  const isProgramDetailPage = programDetailParentSlugs?.reduce((acc, parentSlug) => {return acc || normalizedPath?.includes(parentSlug) && normalizedPath !== parentSlug;
+  const isProgramDetailPage = programDetailParentSlugs?.reduce((acc, parentSlug) => {return acc || normalizedPath?.startsWith(`${parentSlug}/`) && normalizedPath !== parentSlug;
   }, false);
 
   if(isBlogEntryPage) {


### PR DESCRIPTION
## Issue
Corresponding migration of PromoLinkList component as implemented in [UTEG project #5931](https://github.com/techlottus/portalverse/pull/189).

## Solution
- [X] Updated program query & types 4f7235e.
- [X] Retrieved dynamic program data by slug 4165805.
- [X] Conditionally render program detail pages content 134bc1f.
- [X] Blog entry and program detail pages paths validation 2edb96b.

## Testing
Repeat the same steps as described in the related URL in the PR's issue.

You can use these already captured programs for the UANE staging environment:
  - Bachillerato
    - [Strapi Item](https://strapi.staging.uane.edu.mx/admin/content-manager/collectionType/api::program.program/10)
    - Program Slug: `/programa-de-prueba-bachillerat`
    - Path: `/oferta-educativa/bachillerato/programa-de-prueba-bachillerat`
    - [Preview](https://portalverse-uane-git-feat-dev-5997-techlottus.vercel.app/oferta-educativa/bachillerato/programa-de-prueba-bachillerat)
  - Licenciatura
    - [Strapi Item](https://strapi.staging.uane.edu.mx/admin/content-manager/collectionType/api::program.program/1)
    - Program Slug: `/licenciatura-en-derecho`
    - Path: `/oferta-educativa/licenciatura/licenciatura-en-derecho`
    - [Preview](https://portalverse-uane-git-feat-dev-5997-techlottus.vercel.app/oferta-educativa/licenciatura/licenciatura-en-derecho)
  - Educación Continua
    - [Strapi Item](https://strapi.staging.uane.edu.mx/admin/content-manager/collectionType/api::program.program/9)
    - Program Slug: `/prueba-programa-extension-universitaria`
    - Path: `/extension-universitaria/prueba-programa-extension-universitaria`
    - [Preview](https://portalverse-uane-git-feat-dev-5997-techlottus.vercel.app/extension-universitaria/prueba-programa-extension-universitaria)
 - Currently, for each of these pages you should only see a text indicating what type of program it is, either "Bachillerato", "Educación Continua" or "Nivel Superior". Validate that the text matches the program level.