### PR TITLE
[DEV-5999] Continuous education detail page component migration

### DIFF
--- a/components/DynamicProgramContent.tsx
+++ b/components/DynamicProgramContent.tsx
@@ -1,4 +1,5 @@
 import { Fragment } from "react";
+import ContinuousEducationProgramDetail from "@/components/sections/ContEdProgramDetail";
 import type { DynamicProgramDetailData } from "@/utils/pages";
 
 const DynamicProgramContent = (props: DynamicProgramDetailData) => {
@@ -9,7 +10,7 @@ const DynamicProgramContent = (props: DynamicProgramDetailData) => {
   const renderContent = () => {
     switch(level) {
       case "Educación Continua": {
-        return <h1>Agregar Renderer de Educación Continua</h1>
+        return <ContinuousEducationProgramDetail {...programAttributes} />
       }
       case "Bachillerato": {
         return <h1>Agregar Renderer de Bachillerato</h1>

--- a/components/sections/ContEdProgramDetail.tsx
+++ b/components/sections/ContEdProgramDetail.tsx
@@ -1,0 +1,99 @@
+import Image from "next/image";
+import Aspect from "@/components/Aspect";
+import ContentLayout from "@/layouts/Content.layout";
+import RichtText from "@/old-components/Richtext/Richtext";
+import parseEditorRawData from "@/utils/parseEditorRawData";
+import type { FC } from "react";
+import type { ProgramAttributes } from "@/utils/getProgramBySlug";
+import cn from "classnames";
+
+const mxnCurrency = new Intl.NumberFormat("es-MX", {
+  style: "currency",
+  currency: "MXN",
+});
+
+const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramAttributes) => {
+  const { 
+    name,
+    detail,
+    image,
+    price,
+    offerPrice,
+    priceDetail
+   } = props;
+
+  const programDetail = parseEditorRawData(detail);
+  const programImage = image?.data?.attributes;
+  const programPriceDetail = parseEditorRawData(priceDetail);
+
+  return (
+    <ContentLayout classNames="gap-6">
+      <div className="col-span-6 w-t:col-span-4 w-p:col-span-4">
+        <div className="flex flex-col gap-6">
+          {
+            name ?
+              <h1 className="font-Poppins font-bold text-13 w-t:text-8.5 w-p:text-7.5 leading-13 w-t:leading-[111%] w-p:leading-[125%]">{name}</h1>
+              : null
+          }
+          {
+            programDetail ?
+              <RichtText data={{
+                content: programDetail
+              }} />
+              : null
+          }
+        </div>
+      </div>
+      <div className="col-span-6 w-t:col-span-4 w-p:col-span-4">
+        {
+          programImage?.url ?
+          <Aspect ratio="2/1">
+            <Image
+              alt={programImage?.alternativeText || ""}
+              src={programImage?.url}
+              fill
+            />
+          </Aspect>
+            : null
+        }
+        <div className="flex flex-col gap-2 p-2 border rounded-lg my-6">
+          {
+            !!price ?
+              <div className="flex flex-col">
+                <span className="font-Nunito-Sans font-normal text-base leading-5 text-[#818181]">Precio:</span>
+                <div className="flex items-end gap-2">
+                  <span
+                    className={cn(
+                        "font-Poppins font-semibold",
+                        {
+                          "text-8 leading-12": !offerPrice,
+                          "text-2xl leading-10 line-through": !!offerPrice
+                        }
+                      )
+                    }
+                  >
+                    {mxnCurrency?.format(price)}
+                  </span>
+                  {
+                    offerPrice ?
+                      <span className="text-4xl leading-12">{mxnCurrency?.format(offerPrice)}</span>
+                      : null
+                  }
+                </div>
+              </div>
+              : null
+          }
+          {
+            programPriceDetail ?
+              <RichtText data={{
+                content: programPriceDetail
+              }} />
+              : null
+          }
+        </div>
+      </div>
+    </ContentLayout>
+  );
+};
+
+export default ContinuousEducationProgramDetail;

--- a/utils/getProgramBySlug.ts
+++ b/utils/getProgramBySlug.ts
@@ -46,27 +46,29 @@ type ProgramModalitiesDetail = {
   curriculums: Array<CurriculumDetail>
 }
 
-export type ProgramData = {
-  id: number;
-  attributes: {
-    slug: string;
-    name: string;
-    description: string;
-    image: StrapiImage;
-    detail: string;
-    programModalities: Array<ProgramModalitiesDetail>;
-    level: {
-      data: {
-        attributes: {
-          title: ProgramLevel;
-        }
+export type ProgramAttributes = {
+  slug: string;
+  name: string;
+  description: string;
+  image: StrapiImage;
+  detail: string;
+  programModalities: Array<ProgramModalitiesDetail>;
+  level: {
+    data: {
+      attributes: {
+        title: ProgramLevel;
       }
     }
-    price: number;
-    offerPrice: number;
-    priceDetail: string;
   }
-}
+  price: number;
+  offerPrice: number;
+  priceDetail: string;
+};
+
+export type ProgramData = {
+  id: number;
+  attributes: ProgramAttributes;
+};
 
 type ProgramBySlugResponse = {
   programs: {


### PR DESCRIPTION
## Issue
Corresponding migration of PromoLinkList component as implemented in [UTEG project #5954](https://github.com/techlottus/portalverse/pull/192).

## Solution
- [X] Updated ProgramData type 96923c3.
- [X] Created continuous education program detail component fba28ea.
- [X] Added cont education component to dynamic program content 8990589.

## Testing
Repeat the same steps as described in the related URL in the PR's issue.

You can use these already captured programs for the UANE staging environment:
 - Educación Continua
    - [Strapi Item](https://strapi.staging.uteg.edu.mx/admin/content-manager/collectionType/api::program.program/4)
    - Program Slug: `/prueba-programa-extension-universitaria`
    - Path: `/extension-universitaria/prueba-programa-extension-universitaria`
    - [Preview](https://portalverse-uane-git-feat-dev-5999-techlottus.vercel.app/extension-universitaria/prueba-programa-extension-universitaria)