### PR TITLE
[DEV-5953] Fix variables pagination UANE

### DIFF
--- a/pages/[...slug].tsx
+++ b/pages/[...slug].tsx
@@ -66,7 +66,7 @@ export async function getStaticPaths() {
     blogEntryPageData?.data?.attributes?.slug
   );
 
-  const blogPostsData = await getBlogPosts({ pageSize: 100 });
+  const blogPostsData = await getBlogPosts({ limit: -1 });
   const blogEntriesSlugs = blogPostsData?.blogPosts?.data?.map((blogPost) =>
     normalizePath(blogPost?.attributes?.slug)
   );

--- a/pages/voz-uane/blog/index.tsx
+++ b/pages/voz-uane/blog/index.tsx
@@ -56,7 +56,7 @@ const Blog: NextPageWithLayout = ({ sections, meta, strapi }: any) => {
 export async function getStaticProps(context: any) {	
   const { sections, meta } = await getDataPageFromJSON('blog/blog.json');
   const blogPostsData = await getBlogPosts({
-    pageSize: 100,
+    limit: 100,
     sort: "publication_date:desc"
   });
 

--- a/pages/voz-uane/blog/index.tsx
+++ b/pages/voz-uane/blog/index.tsx
@@ -56,7 +56,7 @@ const Blog: NextPageWithLayout = ({ sections, meta, strapi }: any) => {
 export async function getStaticProps(context: any) {	
   const { sections, meta } = await getDataPageFromJSON('blog/blog.json');
   const blogPostsData = await getBlogPosts({
-    limit: 100,
+    limit: -1,
     sort: "publication_date:desc"
   });
 

--- a/pages/voz-uane/index.tsx
+++ b/pages/voz-uane/index.tsx
@@ -90,7 +90,7 @@ export async function getStaticProps(context: any) {
   }
 
   const blogPostsData = await getBlogPosts({
-    pageSize: 100,
+    limit: 100,
     sort: "publication_date:desc"
   });
 

--- a/pages/voz-uane/index.tsx
+++ b/pages/voz-uane/index.tsx
@@ -90,7 +90,7 @@ export async function getStaticProps(context: any) {
   }
 
   const blogPostsData = await getBlogPosts({
-    limit: 100,
+    limit: -1,
     sort: "publication_date:desc"
   });
 

--- a/utils/getBlogPosts.ts
+++ b/utils/getBlogPosts.ts
@@ -15,6 +15,7 @@ const getBlogPosts = async (variables: BlogPostsVariables) => {
     limit,
     sort,
   });
+
   return data;
 };
 

--- a/utils/getBlogPosts.ts
+++ b/utils/getBlogPosts.ts
@@ -8,7 +8,7 @@ export type BlogPostsVariables = {
 };
 
 const getBlogPosts = async (variables: BlogPostsVariables) => {
-  const { start = 1, limit, sort } = variables;
+  const { start = 0, limit, sort } = variables;
 
   const data = await fetchStrapiGraphQL<BlogPostsData>(BLOG_POSTS, {
     start,

--- a/utils/getBlogPosts.ts
+++ b/utils/getBlogPosts.ts
@@ -2,20 +2,19 @@ import { fetchStrapiGraphQL } from "@/utils/getStrapi";
 import type { StrapiImage } from "@/types/strapi/common";
 
 export type BlogPostsVariables = {
-  page?: number;
-  pageSize?: number;
+  start?: number;
+  limit?: number;
   sort?: "publication_date:desc" | "publication_date:asc";
 };
 
 const getBlogPosts = async (variables: BlogPostsVariables) => {
-  const { page = 1, pageSize, sort } = variables;
+  const { start = 1, limit, sort } = variables;
 
   const data = await fetchStrapiGraphQL<BlogPostsData>(BLOG_POSTS, {
-    page,
-    pageSize,
+    start,
+    limit,
     sort,
   });
-
   return data;
 };
 
@@ -37,8 +36,8 @@ export type BlogPostsData = {
 }
 
 const BLOG_POSTS = `
-query BlogPosts ($page: Int, $pageSize: Int, $sort: [String]) {
-  blogPosts(pagination: { page: $page, pageSize: $pageSize }, sort: $sort){
+query BlogPosts ($start: Int, $limit: Int, $sort: [String]) {
+  blogPosts(pagination: { start: $start, limit: $limit }, sort: $sort){
     data {
       attributes {
         title

--- a/utils/getPodcastEpisodes.ts
+++ b/utils/getPodcastEpisodes.ts
@@ -1,19 +1,19 @@
 import { fetchStrapiGraphQL } from "@/utils/getStrapi";
 
 export type PodcastEpisodesVariables = {
-  page?: number;
-  pageSize?: number;
+  start?: number;
+  limit?: number;
   sort?: "publicationDate:desc" | "publicationDate:asc";
 };
 
 const getPodcastEpisodes = async (variables: PodcastEpisodesVariables) => {
-  const { page = 1, pageSize, sort = "publicationDate:desc" } = variables;
+  const { start = 1, limit, sort = "publicationDate:desc" } = variables;
 
   const data = await fetchStrapiGraphQL<PodcastEpisodesResponse>(
     PODCAST_EPISODES,
     {
-      page,
-      pageSize,
+      start,
+      limit,
       sort,
     }
   );
@@ -37,7 +37,7 @@ export type PodcastEpisodesResponse = {
 
 const PODCAST_EPISODES = `
 query PodcastEpisodes($sort: [String]) {
-  podcasts(filters: { type: { eq: "episode" } }, sort: $sort) {
+  podcasts(filters: { type: { eq: "episode" } }, sort: $sort, pagination: {start: 0, limit: -1}) {
     data {
       attributes {
         providerId

--- a/utils/getPodcastEpisodes.ts
+++ b/utils/getPodcastEpisodes.ts
@@ -7,7 +7,7 @@ export type PodcastEpisodesVariables = {
 };
 
 const getPodcastEpisodes = async (variables: PodcastEpisodesVariables) => {
-  const { start = 1, limit, sort = "publicationDate:desc" } = variables;
+  const { start = 0, limit, sort = "publicationDate:desc" } = variables;
 
   const data = await fetchStrapiGraphQL<PodcastEpisodesResponse>(
     PODCAST_EPISODES,
@@ -36,8 +36,8 @@ export type PodcastEpisodesResponse = {
 };
 
 const PODCAST_EPISODES = `
-query PodcastEpisodes($sort: [String]) {
-  podcasts(filters: { type: { eq: "episode" } }, sort: $sort, pagination: {start: 0, limit: -1}) {
+query PodcastEpisodes($start: Int, $limit: Int, $sort: [String]) {
+  podcasts(filters: { type: { eq: "episode" } }, sort: $sort, pagination: {start: $start, limit: $limit}) {
     data {
       attributes {
         providerId

--- a/utils/strapi/sections/BlogPostsPodcast.ts
+++ b/utils/strapi/sections/BlogPostsPodcast.ts
@@ -97,7 +97,7 @@ export const formatBlogPostsPodcastSection = async (
   const blogEntryPage = await getBlogEntryPageData();
 
   const blogPostsData = await getBlogPosts({
-    pageSize: blogPostsConfig?.maxentries,
+    limit: blogPostsConfig?.maxentries,
     sort:
       blogPostsConfig?.sortdate === "latest"
         ? "publication_date:desc"

--- a/utils/strapi/sections/Listconfig.ts
+++ b/utils/strapi/sections/Listconfig.ts
@@ -46,6 +46,7 @@ export const formatListconfigSection = async (
   switch (section?.relatesto) {
     case "blogentries": {
       const blogEntryPage = await getBlogEntryPageData();
+
       const blogPostsData = await getBlogPosts({
         limit: section?.maxentries,
         sort:
@@ -63,6 +64,7 @@ export const formatListconfigSection = async (
           blogPosts,
         };
       }
+
       break;
     }
     case "podcasts": {

--- a/utils/strapi/sections/Listconfig.ts
+++ b/utils/strapi/sections/Listconfig.ts
@@ -46,15 +46,13 @@ export const formatListconfigSection = async (
   switch (section?.relatesto) {
     case "blogentries": {
       const blogEntryPage = await getBlogEntryPageData();
-
       const blogPostsData = await getBlogPosts({
-        pageSize: section?.maxentries,
+        limit: section?.maxentries,
         sort:
           section?.sortdate === "latest"
             ? "publication_date:desc"
             : "publication_date:asc",
-      });
-
+      }); 
       const blogPageSlug = blogEntryPage?.data?.attributes?.slug;
       const blogPosts = blogPostsData?.blogPosts?.data;
 
@@ -64,12 +62,11 @@ export const formatListconfigSection = async (
           blogPosts,
         };
       }
-
       break;
     }
     case "podcasts": {
       const podcastEpisodes = await getPodcastEpisodes({
-        pageSize: section?.maxentries,
+        limit: section?.maxentries,
         sort:
           section?.sortdate === "latest"
             ? "publicationDate:desc"

--- a/utils/strapi/sections/Listconfig.ts
+++ b/utils/strapi/sections/Listconfig.ts
@@ -52,7 +52,8 @@ export const formatListconfigSection = async (
           section?.sortdate === "latest"
             ? "publication_date:desc"
             : "publication_date:asc",
-      }); 
+      });
+
       const blogPageSlug = blogEntryPage?.data?.attributes?.slug;
       const blogPosts = blogPostsData?.blogPosts?.data;
 


### PR DESCRIPTION
## Issue
we need to change the pagination variables in the blopost query to get the maxentries, the following pagination has been placed: pagination: `{ start: $start, limit: $limit }` where the value of the start variable is 1 and limit is defined with the maxentries that comes from strapi, when performing tests and placing a -1 we are shown all the available data, the value is not allowed to be null since this is defined from strapi.

we need to change the paging variables in the podcastEpisodes query to get the maxentries, just like blogpost the limit variable will come from strapi's maxentries



