### PR TITLE
[DEV-6027] Refactor Continuous Education programs visibility migration

### DIFF
--- a/components/sections/ContEdPrograms.tsx
+++ b/components/sections/ContEdPrograms.tsx
@@ -1,7 +1,6 @@
 import { useRouter } from "next/router";
 import Container from "@/layouts/Container.layout";
 import CardProgram from "@/old-components/CardProgram/CardProgram";
-import cn from "classnames";
 import type { ContEdProgramsSection } from "@/utils/strapi/sections/ContEdPrograms";
 
 const ContEdPrograms = (props: ContEdProgramsSection) => {

--- a/utils/pages.ts
+++ b/utils/pages.ts
@@ -12,6 +12,10 @@ import { getDataPageFromJSON } from "@/utils/getDataPage";
 import { isValidPath, normalizePath } from "@/utils/misc";
 import type { PageEntityResponse } from "@/utils/getPageDataById";
 import type { ProgramData } from "@/utils/getProgramBySlug";
+import type {
+  StaticContinuousEducationCategory,
+  StaticContinuousEducationProgram,
+} from "@/utils/strapi/sections/ContEdPrograms";
 
 type PageType = "programDetail" | "blogEntry" | "dynamic";
 
@@ -171,23 +175,38 @@ export const getDynamicPagesPaths = async () => {
   return dynamicPagesPaths;
 }
 
-export const getJSONProgramsPaths = () => {
-  const educationalOfferingItems = Routes["oferta-educativa"];
-  const continuousEducationItems = Routes["extension-universitaria"];
+export const getJSONProgramsPaths = async () => {
+  const educationalOfferingParams = Routes["oferta-educativa"];
+  const continuousEducationParams = Routes["extension-universitaria"];
+
+  const continuousEducationStaticPageData = await getDataPageFromJSON('extension-universitaria/extension-universitaria.json');
+  const continuousEducationStaticCategories = continuousEducationStaticPageData?.sections?.extension?.sections as Array<StaticContinuousEducationCategory>;
+  const hiddenContinuousEducationProgramsPaths =
+    continuousEducationStaticCategories
+      ?.reduce((programs, category) => { // merge all programs from all categories
+        return [...programs, ...category?.cursos];
+      }, [] as Array<StaticContinuousEducationProgram>)
+      ?.filter((program) => program?.hidden)
+      ?.map((program) => program?.redirect);
 
   const paths: Array<string> = [];
 
-  educationalOfferingItems?.forEach(level => {
+  educationalOfferingParams?.forEach(level => {
     level?.params?.programs?.forEach(program => {
       const path = `${level?.params?.levelRoute}/${program?.params?.program}`;
       paths?.push(path);
     })
   });
 
-  continuousEducationItems?.params?.programs?.forEach(program => {
-    const path = `extension-universitaria/${program?.params?.program}`;
-    paths?.push(path);
-  })
+  // Generate paths for every non hidden static Continuous Education program.
+  continuousEducationParams?.params?.programs
+    ?.filter((program) => {
+      return !hiddenContinuousEducationProgramsPaths?.includes(program?.params?.program)
+    })
+    ?.forEach((program) => {
+      const path = `extension-universitaria/${program?.params?.program}`;
+      paths?.push(path);
+    });
 
   return paths;
 }
@@ -215,7 +234,7 @@ export const getDynamicProgramsPaths = async () => {
 
 export const getProgramDetailPagesPaths = async () => {
   const strapiProgramDetailPagesPaths = await getDynamicProgramsPaths();
-  const staticProgramDetailPagesPaths = getJSONProgramsPaths();
+  const staticProgramDetailPagesPaths = await getJSONProgramsPaths();
 
   const paths = [...strapiProgramDetailPagesPaths, ...staticProgramDetailPagesPaths]?.map(normalizePath);
   const set = Array.from(new Set(paths)); // remove duplicates

--- a/utils/strapi/sections/ContEdPrograms.ts
+++ b/utils/strapi/sections/ContEdPrograms.ts
@@ -53,7 +53,7 @@ export const CONT_ED_PROGRAMS = `
 }
 `;
 
-type StaticProgram = {
+export type StaticContinuousEducationProgram = {
   hidden: boolean;
   id: string;
   title: string;
@@ -78,12 +78,12 @@ type StaticProgram = {
   redirect: string;
 }
 
-type StaticProgramCategory = {
+export type StaticContinuousEducationCategory = {
   title: string;
-  cursos: Array<StaticProgram>
+  cursos: Array<StaticContinuousEducationProgram>
 }
 
-const formatStaticProgramCategory = (category: StaticProgramCategory): ContinuousEducationCategory => {
+const formatStaticProgramCategory = (category: StaticContinuousEducationCategory): ContinuousEducationCategory => {
   return {
     attributes: {
       name: category?.title,
@@ -107,30 +107,43 @@ const formatStaticProgramCategory = (category: StaticProgramCategory): Continuou
   }
 }
 
+const excludeHiddenPrograms = (category: StaticContinuousEducationCategory) => {
+  return {
+    ...category,
+    cursos: category?.cursos?.filter(
+      (program) => !program?.hidden
+    ),
+  };
+}
+
+const hasAtLeastOneProgram = (category: StaticContinuousEducationCategory) => {
+  return category?.cursos?.length > 0;
+}
+
 export const formatContEdProgramsSection = async(section: ContEdProgramsSection) => {
-  const staticProgramsData = await getDataPageFromJSON('extension-universitaria/extension-universitaria.json');
-  const staticProgramCategories = staticProgramsData?.sections?.extension?.sections as Array<StaticProgramCategory>;
+  const continuousEducationStaticPageData = await getDataPageFromJSON('extension-universitaria/extension-universitaria.json');
+  const staticCategories = continuousEducationStaticPageData?.sections?.extension?.sections as Array<StaticContinuousEducationCategory>;
+  const formattedStaticCategories = staticCategories
+    ?.map(excludeHiddenPrograms)
+    ?.filter(hasAtLeastOneProgram)
+    ?.map(formatStaticProgramCategory)
 
-  const formattedStaticProgramCategories = staticProgramCategories?.map(formatStaticProgramCategory);
+  const categories = section?.categories?.data;
 
-  const categories = section.categories.data;
+  categories?.forEach(category => {
+    const categoryName = category?.attributes?.name;
+    const programs = category?.attributes?.programs?.data;
 
-  /**
-   * Group programs under the same category.
-   * Append categories that are not currently captured in Strapi but exist in the static JSON file. 
-   */
-  formattedStaticProgramCategories?.forEach(staticProgramCategory => {
-    const staticCategoryName = staticProgramCategory?.attributes?.name;
+    // Retrieve static programs under the given category.
+    const staticPrograms =
+      formattedStaticCategories?.find(
+        (programCategory) => programCategory?.attributes?.name === categoryName
+      )?.attributes?.programs?.data || [];
 
-    // Find if a category coming from the JSON file already exists within the categories retrieved from Strapi.
-    const foundCategory = categories?.find(category => category?.attributes?.name === staticCategoryName);
-
-    if(!!foundCategory) { // merge both programs under the same category
-      const programs = foundCategory.attributes.programs?.data;
-      foundCategory.attributes.programs.data = [...programs, ...staticProgramCategory?.attributes?.programs?.data];
-    } else { // append the new category object
-      section.categories.data = [...section.categories.data, staticProgramCategory]
-    }
+    category.attributes.programs.data = [
+      ...programs,
+      ...staticPrograms,
+    ];
 
   });
 


### PR DESCRIPTION
## Issue
Corresponding migration of PromoLinkList component as implemented in [UTEG project #5994](https://github.com/techlottus/portalverse/pull/198).

## Solution
- [X] Remove unused import 95bfe6a.
- [X] Excluded hidden programs from ContEdPrograms section 2294fef.
- [X] Excluded hidden programs from page path generation 9b793dd.

## Testing
Repeat the same steps as described in the related URL in the PR's issue.