### PR TITLE
[DEV-6042] Fixes/Adjustments (static path generation; PodcastList & Banner components) migration

### DIFF
--- a/components/sections/BlogPostsPodcast.tsx
+++ b/components/sections/BlogPostsPodcast.tsx
@@ -2,8 +2,8 @@ import { useRouter } from "next/router";
 import Container from "@/layouts/Container.layout";
 import BannerWrapper from "@/old-components/BannerWrapper";
 import Button from "@/old-components/Button/Button";
-import Spotify from "@/old-components/Spotify";
 import BlogPostCardWrapper from "@/components/BlogPostCardWrapper";
+import PodcastList from "@/components/sections/PodcastList";
 import type { BlogPostsPodcastSection } from "@/utils/strapi/sections/BlogPostsPodcast";
 
 const BlogPostsPodcast = (props: BlogPostsPodcastSection) => {
@@ -82,36 +82,17 @@ const BlogPostsPodcast = (props: BlogPostsPodcastSection) => {
             }
           </div>
 
-          {/* Podcast Sidebar */}
-          <div className="col-span-4 w-t:col-span-8 w-p:col-span-4">
-            {
-              podcastItemsTitle
-                ? <p className="font-Poppins font-bold text-10 w-t:text-7.5 w-p:text-7.5 leading-[125%] mb-6">
-                    {podcastItemsTitle}
-                  </p>
-                : null
-            }
-            {
-              podcastItems?.length > 0
-                ? <div>
-                    {
-                      podcastItems?.map((podcastItem, i) => (
-                        <div className="mb-6" key={`section-articles-${i}`}>
-                          <Spotify
-                            data={{
-                              config: {
-                                type: podcastItem?.podcastItem?.data?.attributes?.type,
-                                id: podcastItem?.podcastItem?.data?.attributes?.providerId,
-                                format: podcastItem?.format,
-                              },
-                            }}
-                          />
-                        </div>
-                      ))
-                    }
-                  </div>
-                : null
-            }
+          {/* Sidebar */}
+          <div className="col-span-4 w-t:col-span-8 w-p:col-span-4 w-d-base:-mx-6">
+            
+            {/* Podcast Items */}
+            <PodcastList
+              type="ComponentSectionsPodcastList"
+              title={podcastItemsTitle}
+              podcastItems={podcastItems}
+            />
+
+            {/* Banners */}
             {
               banners?.length > 0
                 ? <div>

--- a/components/sections/PodcastList.tsx
+++ b/components/sections/PodcastList.tsx
@@ -14,21 +14,32 @@ const PodcastList = (props: PodcastListSection) => {
           </p>
         ) : null}
         {podcastItems?.length > 0
-          ? podcastItems?.map((podcastItem, i) => (
-              <div key={`section-articles-${i}`}>
-                <Spotify
-                  data={{
-                    config: {
-                      type: "episode",
-                      id: podcastItem?.podcastItem?.data?.attributes
-                        ?.providerId,
-                      format: podcastItem?.format,
-                    },
-                  }}
-                />
-              </div>
-            ))
-          : null}
+          ? <div className="flex flex-col space-y-6">
+              {
+                podcastItems?.map((item, i) => {
+                  const attributes = item?.podcastItem?.data?.attributes;
+                  const type = attributes?.type;
+                  const id = attributes?.providerId;
+                  const format = item?.format || "compact";
+
+                  return (
+                    <div key={`section-articles-${i}`}>
+                      <Spotify
+                        data={{
+                          config: {
+                            type,
+                            id,
+                            format,
+                          },
+                        }}
+                      />
+                    </div>
+                  );
+                })
+              }
+            </div>
+          : null
+        }
       </Container>
     </section>
   );

--- a/old-components/SliderPortalverse.tsx
+++ b/old-components/SliderPortalverse.tsx
@@ -227,7 +227,7 @@ const SliderPortalverse: FC<SliderPortalverseProps> = (
                         ? <div className={cn("w-full flex", {
                             ["justify-center"]: item?.textPosition === "center_top" || item?.textPosition === "center" || item?.textPosition === "center_bottom",
                             ["justify-start"]: item?.textPosition === "left_top" || item?.textPosition === "left_bottom",
-                            ["justify-end"]: item?.textPosition === "right_top" || item?.textPosition === "right_bottom",
+                            ["justify-end"]: item?.textPosition === "right_top" || item?.textPosition === "right_bottom" || item?.textPosition === "right_center",
                           })}>
                             <Button
                               darkOutlined={item?.contentVariant === "light"}

--- a/utils/pages.ts
+++ b/utils/pages.ts
@@ -92,7 +92,7 @@ export const getProgramDetailPageData = async (path: string): Promise<ProgramDet
   const levelSlug = pathSegments?.slice(pathSegments?.length - 2, pathSegments?.length - 1)?.[0];
   const programSlug = pathSegments?.slice(pathSegments?.length - 1, pathSegments?.length)?.[0];
 
-  const staticProgramsItemsByLevel = Routes["oferta-educativa"];
+  const staticProgramsByLevel = Routes["oferta-educativa"];
   const continuousEducationPrograms = Routes["extension-universitaria"]?.params?.programs;
 
   const isContinuousEducationProgram = levelSlug === "extension-universitaria";
@@ -101,9 +101,9 @@ export const getProgramDetailPageData = async (path: string): Promise<ProgramDet
     ? continuousEducationPrograms?.some((program) => {
         return program?.params?.program === programSlug;
       })
-    : staticProgramsItemsByLevel?.some((item) => {
-        return item?.params?.programs?.some((program) => {
-          return program?.params?.program === programSlug;
+    : staticProgramsByLevel?.some((level) => {
+        return level?.params?.programs?.some((program) => {
+          return level?.params?.level === levelSlug && program?.params?.program === programSlug;
         });
       });
 

--- a/utils/strapi/sections/PodcastList.ts
+++ b/utils/strapi/sections/PodcastList.ts
@@ -3,6 +3,7 @@ type PodcastItem = {
   podcastItem: {
     data: {
       attributes: {
+        type: "playlist" | "episode" | "album" | "artist" | "track";
         providerId: string;
       };
     };
@@ -23,6 +24,7 @@ export const PODCAST_LIST = `
     podcastItem {
       data {
         attributes {
+          type
           providerId
         }
       }


### PR DESCRIPTION
## Issue
Corresponding migration of PromoLinkList component as implemented in [UTEG project #6022](https://github.com/techlottus/portalverse/pull/202).

## Solution
- [X] Account for program level during paths generation 2cc5195.
- [X] Adjust button alignment a866db0.
- [X] Retrieve podcast item type 5732067.
- [X] Passed correct podcast item "type" to Spotify component da8ca72.
- [X] Removed duplicated code for PodcastList 19fe847.

## Testing
Repeat the same steps as described in the related URL in the PR's issue.

- Checkout to PR.
- Run `yarn && yarn dev`
- Navigate to `/cumple-de-beto`.
- The first component is a `HeroSlider` section component with a single side with its `textPosition` set to `right center`. Validate that the button is aligned to the right.
- The third component is a `PodcastList` section component, with its first item being of type `playlist`. Validate that a Spotify playlist is displayed and no errors are shown.
