### PR TITLE
[ENG-311] Migración de sección BlogPosts de la página de Internacionalización UANE

### DIFF
--- a/components/sections/BlogPosts.tsx
+++ b/components/sections/BlogPosts.tsx
@@ -19,7 +19,7 @@ const BlogPosts = (props: BlogPostsSection) => {
         <div className="flex flex-col space-y-6">
         {
             title
-              ? <div className="col-span-12 w-t:col-span-8 w-p:col-span-4 w-t:mt-6 w-p:mt-6">
+              ? <div className="col-span-12 w-t:col-span-8 w-p:col-span-4">
                   <p className="font-Poppins font-bold text-8.5 w-t:text-6 w-p:text-6 leading-[111%] w-t:leading-[125%] w-p:leading-[125%]">
                     {title}
                   </p>

--- a/components/sections/BlogPosts.tsx
+++ b/components/sections/BlogPosts.tsx
@@ -1,8 +1,7 @@
 import { useRouter } from "next/router";
 import Container from "@/layouts/Container.layout";
 import BlogPostCardWrapper from "@/components/BlogPostCardWrapper";
-import { BlogPostsSection } from "@/utils/strapi/sections/BlogPosts";
-
+import type { BlogPostsSection } from "@/utils/strapi/sections/BlogPosts";
 
 const BlogPosts = (props: BlogPostsSection) => {
 

--- a/components/sections/BlogPosts.tsx
+++ b/components/sections/BlogPosts.tsx
@@ -1,0 +1,56 @@
+import { useRouter } from "next/router";
+import Container from "@/layouts/Container.layout";
+import BlogPostCardWrapper from "@/components/BlogPostCardWrapper";
+import { BlogPostsSection } from "@/utils/strapi/sections/BlogPosts";
+
+
+const BlogPosts = (props: BlogPostsSection) => {
+
+  const router = useRouter();
+
+  const title = props?.title;
+  const blogPosts = props?.blogPosts;
+  const blogPageSlug = props?.blogPageSlug;
+
+  if (!blogPosts || blogPosts?.length < 1) return null;
+
+  return (
+    <section>
+      <Container>
+        <div className="flex flex-col space-y-6">
+        {
+            title
+              ? <div className="col-span-12 w-t:col-span-8 w-p:col-span-4 w-t:mt-6 w-p:mt-6">
+                  <p className="font-Poppins font-bold text-8.5 w-t:text-6 w-p:text-6 leading-[111%] w-t:leading-[125%] w-p:leading-[125%]">
+                    {title}
+                  </p>
+                </div>
+              : null
+          }
+          {
+            blogPosts?.length > 0
+              ? <div className="grid w-d:grid-cols-3 gap-6 w-t:grid-cols-2 w-p:grid-cols-1">
+                  {
+                    blogPosts?.map((blogPost, i) => (
+                      <div key={`section-blog-${i}`}>
+                        <BlogPostCardWrapper
+                          onClick={() =>
+                            router.push(`${blogPageSlug}/${blogPost.attributes.slug}`)
+                          }
+                          data={{
+                            ...blogPost,
+                          }}
+                        />
+                      </div>
+                    ))
+                  }
+                </div>
+              : null
+          }
+        </div>
+      </Container>
+    </section>
+  );
+}
+
+export default BlogPosts

--- a/pages/nosotros/internacionalizacion.tsx
+++ b/pages/nosotros/internacionalizacion.tsx
@@ -88,11 +88,11 @@ const Internacionalizacion = ({ sections, meta, blogPostsSection }: {sections: a
           <Rainbow classNamesTitle="ml-6" sections={sections.rainbow.sections} title={sections.rainbow.title} />
         </div>
       </ContentFullLayout>
-      <ContentLayout>
-        <div className="col-span-12 w-t:col-span-8 w-p:col-span-4 mb-6 w-t:mb-12 w-p:mb-6">
-          <p className="font-Poppins font-bold text-10 w-t:text-6 w-p:text-6 leading-[125%]">{sections.alliances.title}</p>
+      <ContentLayout classNames="mt-6 w-d:mt-18">
+        <div className="col-span-12">
+          <p className="font-Poppins font-bold text-10 w-t:text-6 w-p:text-6 leading-[125%] mb-6">{sections.alliances.title}</p>
         </div>
-        <section className="col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-1 mb-12 w-t:mb-12 w-p:mb-6">
+        <section className="col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-1">
           {
            sections.alliances.alliances.map((item:any, i:number) => <section key={`section-alliances-${i}`}>
             <PromoLink data={item} onClick={() => {
@@ -101,16 +101,6 @@ const Internacionalizacion = ({ sections, meta, blogPostsSection }: {sections: a
            </section>)
           }
         </section>
-        {/*<div className="col-span-12 w-t:col-span-8 w-p:col-span-4 mb-6">
-          <p className="font-Poppins font-bold text-10 w-t:text-6 w-p:text-6 leading-[125%]">{sections.articles.title}</p>
-        </div>
-        <section className="col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-2 gap-6 w-t:grid-cols-2 w-p:grid-cols-1">
-          {
-           sections.articles.articles.map((item:any, i:number) => <section key={`section-alliances-${i}`}>
-            <CardWebsite data={item} onClick={()=> router.push(`/voz-uane/blog/${item.redirect}`)}/>
-           </section>)
-          }
-        </section> */}
       </ContentLayout>
       <div className="w-p:mt-12 w-t:mt-12 w-d:mt-18">
         <BlogPosts {...blogPostsSection} />

--- a/pages/nosotros/internacionalizacion.tsx
+++ b/pages/nosotros/internacionalizacion.tsx
@@ -9,14 +9,16 @@ import NextPageWithLayout from "@/types/Layout.types"
 import Slider from "@/old-components/SliderPortalverse"
 import RichtText from "@/old-components/Richtext/Richtext"
 import PromoLink from "@/old-components/PromoLink"
-import CardWebsite from "@/old-components/CardWebsite"
 import { getDataPageFromJSON } from "@/utils/getDataPage"
 import Rainbow from "@/old-components/Rainbow"
 import Modal from "@/old-components/Modal/Modal"
 import ContentInsideLayout from "@/layouts/ContentInside.layout"
+import BlogPosts from "@/components/sections/BlogPosts"
+import { formatBlogPostsSection } from "@/utils/strapi/sections/BlogPosts"
+import type { BlogPostsSection } from "@/utils/strapi/sections/BlogPosts"
 
 
-const Internacionalizacion: NextPageWithLayout = ({ sections, meta }: any) => {
+const Internacionalizacion = ({ sections, meta, blogPostsSection }: {sections: any, meta: any, blogPostsSection: BlogPostsSection}) => {
 
   const router = useRouter();
   // Modal functionality begin
@@ -110,6 +112,9 @@ const Internacionalizacion: NextPageWithLayout = ({ sections, meta }: any) => {
           }
         </section> */}
       </ContentLayout>
+      <div className="w-p:mt-12 w-t:mt-12 w-d:mt-18">
+        <BlogPosts {...blogPostsSection} />
+      </div>
     </HeaderFooterLayout>
   </>
 }
@@ -117,6 +122,29 @@ const Internacionalizacion: NextPageWithLayout = ({ sections, meta }: any) => {
 // `getStaticPaths` requires using `getStaticProps`
 export async function getStaticProps(context: any) {
   const { sections, meta } = await getDataPageFromJSON('internacionalizacion.json');
+
+  /**
+   * This is a representation of the section data that will come from Strapi once
+   * this page can be fully dynamically generated. This will show the 3 latest blog
+   * entries under the "Internacionalziación" category.
+   */
+  const blogPostsSection: BlogPostsSection = {
+    type: "ComponentSectionsBlogPosts",
+    title: "Artículos sobre UANE Internacional",
+    subtitle: "",
+    description: "",
+    maxEntries: 3,
+    sort: "latest",
+    category: {
+      data: {
+        attributes: {
+          title: "Internacionalización",
+        }
+      }
+    }
+  }
+
+  const formattedBlogPostsSection = await formatBlogPostsSection(blogPostsSection);
 
   // redirect not avaliable page
   if (!!meta.hidden) {
@@ -126,7 +154,7 @@ export async function getStaticProps(context: any) {
   }
 
   return {
-    props: { sections, meta }
+    props: { sections, meta, blogPostsSection: formattedBlogPostsSection }
   }
 }
 

--- a/pages/nosotros/internacionalizacion.tsx
+++ b/pages/nosotros/internacionalizacion.tsx
@@ -91,16 +91,16 @@ const Internacionalizacion = ({ sections, meta, blogPostsSection }: {sections: a
       <ContentLayout classNames="mt-6 w-d:mt-18">
         <div className="col-span-12">
           <p className="font-Poppins font-bold text-10 w-t:text-6 w-p:text-6 leading-[125%] mb-6">{sections.alliances.title}</p>
-        </div>
-        <section className="grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-1 mb-12 w-t:mb-12 w-p:mb-6">
+          <section className="grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-1">
           {
-           sections.alliances.alliances.map((item:any, i:number) => <section key={`section-alliances-${i}`}>
-            <PromoLink data={item} onClick={() => {
-              handleOpenModal(item.content)
-            }}/>
-           </section>)
-          }
-        </section>
+            sections.alliances.alliances.map((item:any, i:number) => <section key={`section-alliances-${i}`}>
+              <PromoLink data={item} onClick={() => {
+                handleOpenModal(item.content)
+              }}/>
+            </section>)
+            }
+          </section>
+        </div>
       </ContentLayout>
       <div className="w-p:mt-12 w-t:mt-12 w-d:mt-18">
         <BlogPosts {...blogPostsSection} />

--- a/pages/nosotros/internacionalizacion.tsx
+++ b/pages/nosotros/internacionalizacion.tsx
@@ -92,7 +92,7 @@ const Internacionalizacion = ({ sections, meta, blogPostsSection }: {sections: a
         <div className="col-span-12">
           <p className="font-Poppins font-bold text-10 w-t:text-6 w-p:text-6 leading-[125%] mb-6">{sections.alliances.title}</p>
         </div>
-        <section className="col-span-12 w-t:col-span-8 w-p:col-span-4 grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-1">
+        <section className="grid w-d:grid-cols-4 gap-6 w-t:grid-cols-2 w-p:grid-cols-1 mb-12 w-t:mb-12 w-p:mb-6">
           {
            sections.alliances.alliances.map((item:any, i:number) => <section key={`section-alliances-${i}`}>
             <PromoLink data={item} onClick={() => {

--- a/utils/getBlogPosts.ts
+++ b/utils/getBlogPosts.ts
@@ -15,7 +15,6 @@ const getBlogPosts = async (variables: BlogPostsVariables = {}) => {
   const sort = variables?.sort || "publication_date:desc";
   const category = variables?.category;
 
-
   const data = await fetchStrapiGraphQL<BlogPostsData>(BLOG_POSTS, {
     start,
     limit,

--- a/utils/getBlogPosts.ts
+++ b/utils/getBlogPosts.ts
@@ -5,15 +5,22 @@ export type BlogPostsVariables = {
   start?: number;
   limit?: number;
   sort?: "publication_date:desc" | "publication_date:asc";
+  category?: string;
 };
 
-const getBlogPosts = async (variables: BlogPostsVariables) => {
-  const { start = 0, limit, sort } = variables;
+const getBlogPosts = async (variables: BlogPostsVariables = {}) => {
+
+  const start = variables?.start || 0;
+  const limit = variables?.limit;
+  const sort = variables?.sort || "publication_date:desc";
+  const category = variables?.category;
+
 
   const data = await fetchStrapiGraphQL<BlogPostsData>(BLOG_POSTS, {
     start,
     limit,
     sort,
+    category
   });
 
   return data;
@@ -37,8 +44,12 @@ export type BlogPostsData = {
 }
 
 const BLOG_POSTS = `
-query BlogPosts ($start: Int, $limit: Int, $sort: [String]) {
-  blogPosts(pagination: { start: $start, limit: $limit }, sort: $sort){
+query BlogPosts ($start: Int, $limit: Int, $sort: [String], $category: String) {
+  blogPosts(
+    pagination: { start: $start, limit: $limit }
+    sort: $sort
+    filters: { categories: { title: { eq: $category } } }
+  ) {
     data {
       attributes {
         title

--- a/utils/strapi/sections/BlogPosts.ts
+++ b/utils/strapi/sections/BlogPosts.ts
@@ -1,0 +1,58 @@
+import getBlogEntryPageData from "@/utils/getBlogEntryPageData";
+import getBlogPosts from "@/utils/getBlogPosts";
+import type { BlogPost } from "@/utils/getBlogPosts";
+
+export type BlogPostsSection = {
+  type: "ComponentSectionsBlogPosts";
+  title: string;
+  subtitle: string;
+  description: string;
+  maxEntries: number;
+  sort: "latest" | "earliest";
+  category?: {
+    data: {
+      attributes: {
+        title: string;
+      }
+    }
+  }
+  blogPosts?: Array<BlogPost>; // appended by the formatBlogPostsSection function
+  blogPageSlug?: string; // appended by the formatBlogPostsSection function
+};
+
+export const BLOG_POSTS = `
+... on ComponentSectionsBlogPosts {
+  title
+  subtitle
+  description
+  maxEntries
+  sort
+  category {
+    data {
+      attributes {
+        title
+      }
+    }
+  }
+}
+`;
+
+export const formatBlogPostsSection = async (
+  section: BlogPostsSection
+): Promise<BlogPostsSection> => {
+
+  const { maxEntries, sort, category } = section;
+  
+  const blogPostsData = await getBlogPosts({
+    limit: maxEntries,
+    sort: sort === "earliest" ? "publication_date:asc" : "publication_date:desc",
+    category: category?.data?.attributes?.title
+  });
+
+  const blogEntryPageData = await getBlogEntryPageData();
+
+  section.blogPosts = blogPostsData?.blogPosts?.data;
+  section.blogPageSlug = blogEntryPageData?.data?.attributes?.slug;
+
+  return section;
+};


### PR DESCRIPTION
## Issue

We need to migrate the blogpost rendering code by category to implement it in the internationalization page of the UTEG repository

## Solution
The necessary code for the rendering of the blog notes section related to Internationalization has been migrated
PR migrated:
[https://github.com/techlottus/portalverse/pull/205/files#diff-de28bd6061875ec713a55defd50797c188dddd548076f29e93c9ba57d5382e94](url)

<img width="1467" alt="Captura de pantalla 2023-08-07 a la(s) 17 54 20" src="https://github.com/techlottus/portalverse-uane/assets/116602156/0c409724-ac68-4737-bbb5-ed38e0aebd2a">

