### PR TITLE
[ENG-654] Migration of the Accrodion component from the UTEG repository to the UANE repository

### DIFF
--- a/components/sections/AccordionSection.tsx
+++ b/components/sections/AccordionSection.tsx
@@ -5,10 +5,10 @@ import parseEditorRawData from "@/utils/parseEditorRawData";
 import type { AccordionSection } from "@/utils/strapi/sections/Accordion";
 
 const AccordionComponent = (props: AccordionSection) => {
-  
+
   const { title, subtitle, description, accordionItems } = props;
 
-  const formatedDescription = parseEditorRawData(description);
+  const formatedDescription = parseEditorRawData(description)
 
   const items = accordionItems?.map((item) => {
     const richTextMarkup = parseEditorRawData(item?.content);
@@ -20,8 +20,8 @@ const AccordionComponent = (props: AccordionSection) => {
       content: "<p>content</p>",
       //@ts-ignore
       answer: richTextMarkup,
-      id: "",
-    };
+      id: ""
+    }
     return formattedItem;
   });
 
@@ -29,24 +29,24 @@ const AccordionComponent = (props: AccordionSection) => {
     <section>
       <Container>
         <div className="flex flex-col space-y-6">
-          {title ? (
-            <h3 className="font-Poppins font-bold leading-[125%] w-p:text-6 w-t:text-8.5 text-10">
-              {title}
-            </h3>
-          ) : null}
-          {subtitle ? (
-            <p className="font-Poppins font-semibold leading-[130%] w-p:text-4 w-t:text-4.5 text-5.5">
-              {subtitle}
-            </p>
-          ) : null}
-          {description ? (
-            <div>
-              <RichtText
-                data={{ content: formatedDescription }}
-                classNames="text-xl"
-              />
-            </div>
-          ) : null}
+          {
+            title
+              ? <h3 className="font-Poppins font-bold leading-[125%] w-p:text-6 w-t:text-8.5 text-10">
+                {title}
+              </h3>
+              : null}
+          {
+            subtitle
+              ? <p className="font-Poppins font-semibold leading-[130%] w-p:text-4 w-t:text-4.5 text-5.5">
+                {subtitle}
+              </p>
+              : null
+          }
+          {
+            description
+              ? <div><RichtText data={{ content: formatedDescription }} classNames="text-xl" /></div>
+              : null
+          }
           <div>
             <Accordion data={{ items: items }} />
           </div>
@@ -54,6 +54,6 @@ const AccordionComponent = (props: AccordionSection) => {
       </Container>
     </section>
   );
-};
+}
 
-export default AccordionComponent;
+export default AccordionComponent

--- a/components/sections/AccordionSection.tsx
+++ b/components/sections/AccordionSection.tsx
@@ -1,0 +1,59 @@
+import Container from "@/layouts/Container.layout";
+import Accordion from "@/old-components/Accordion/Accordion";
+import RichtText from "@/old-components/Richtext/Richtext";
+import parseEditorRawData from "@/utils/parseEditorRawData";
+import type { AccordionSection } from "@/utils/strapi/sections/Accordion";
+
+const AccordionComponent = (props: AccordionSection) => {
+
+  const { title, subtitle, description, accordionItems } = props;
+
+  const formatedDescription = parseEditorRawData(description)
+
+  const items = accordionItems?.map((item) => {
+    const richTextMarkup = parseEditorRawData(item?.content);
+    const formattedItem = {
+      icon: "",
+      title: item?.title,
+      iconArrow: "",
+      text: "<p>text</p>",
+      content: "<p>content</p>",
+      //@ts-ignore
+      answer: richTextMarkup,
+      id: ""
+    }
+    return formattedItem;
+  });
+
+  return (
+    <section>
+      <Container>
+        <div className="flex flex-col space-y-6">
+          {
+            title
+              ? <h3 className="font-Poppins font-bold leading-[125%] w-p:text-6 w-t:text-8.5 text-10">
+                {title}
+              </h3>
+              : null}
+          {
+            subtitle
+              ? <p className="font-Poppins font-semibold leading-[130%] w-p:text-4 w-t:text-4.5 text-5.5">
+                {subtitle}
+              </p>
+              : null
+          }
+          {
+            description
+              ? <div><RichtText data={{ content: formatedDescription }} classNames="text-xl" /></div>
+              : null
+          }
+          <div>
+            <Accordion data={{ items: items }} />
+          </div>
+        </div>
+      </Container>
+    </section>
+  );
+}
+
+export default AccordionComponent

--- a/components/sections/AccordionSection.tsx
+++ b/components/sections/AccordionSection.tsx
@@ -5,10 +5,10 @@ import parseEditorRawData from "@/utils/parseEditorRawData";
 import type { AccordionSection } from "@/utils/strapi/sections/Accordion";
 
 const AccordionComponent = (props: AccordionSection) => {
-
+  
   const { title, subtitle, description, accordionItems } = props;
 
-  const formatedDescription = parseEditorRawData(description)
+  const formatedDescription = parseEditorRawData(description);
 
   const items = accordionItems?.map((item) => {
     const richTextMarkup = parseEditorRawData(item?.content);
@@ -20,8 +20,8 @@ const AccordionComponent = (props: AccordionSection) => {
       content: "<p>content</p>",
       //@ts-ignore
       answer: richTextMarkup,
-      id: ""
-    }
+      id: "",
+    };
     return formattedItem;
   });
 
@@ -29,24 +29,24 @@ const AccordionComponent = (props: AccordionSection) => {
     <section>
       <Container>
         <div className="flex flex-col space-y-6">
-          {
-            title
-              ? <h3 className="font-Poppins font-bold leading-[125%] w-p:text-6 w-t:text-8.5 text-10">
-                {title}
-              </h3>
-              : null}
-          {
-            subtitle
-              ? <p className="font-Poppins font-semibold leading-[130%] w-p:text-4 w-t:text-4.5 text-5.5">
-                {subtitle}
-              </p>
-              : null
-          }
-          {
-            description
-              ? <div><RichtText data={{ content: formatedDescription }} classNames="text-xl" /></div>
-              : null
-          }
+          {title ? (
+            <h3 className="font-Poppins font-bold leading-[125%] w-p:text-6 w-t:text-8.5 text-10">
+              {title}
+            </h3>
+          ) : null}
+          {subtitle ? (
+            <p className="font-Poppins font-semibold leading-[130%] w-p:text-4 w-t:text-4.5 text-5.5">
+              {subtitle}
+            </p>
+          ) : null}
+          {description ? (
+            <div>
+              <RichtText
+                data={{ content: formatedDescription }}
+                classNames="text-xl"
+              />
+            </div>
+          ) : null}
           <div>
             <Accordion data={{ items: items }} />
           </div>
@@ -54,6 +54,6 @@ const AccordionComponent = (props: AccordionSection) => {
       </Container>
     </section>
   );
-}
+};
 
-export default AccordionComponent
+export default AccordionComponent;

--- a/utils/Renderers.tsx
+++ b/utils/Renderers.tsx
@@ -1,3 +1,4 @@
+import AccordionComponent from "@/components/sections/AccordionSection";
 import Alert from "@/components/sections/Alert";
 import Banner from "@/components/sections/Banner";
 import BlogPostsPodcast from "@/components/sections/BlogPostsPodcast";
@@ -26,6 +27,7 @@ type Renderer = {
 
 const defaultRenderers: Renderer = {
   paragraph: Paragraph,
+  ComponentSectionsAccordion: AccordionComponent,
   ComponentSectionsAlert: Alert,
   ComponentSectionsBanner: Banner,
   ComponentSectionsBlogPostsPodcast: BlogPostsPodcast,

--- a/utils/strapi/queries.ts
+++ b/utils/strapi/queries.ts
@@ -60,7 +60,7 @@ export type ComponentSection =
   | TextContentSection
 
 export const SECTIONS = `
-${ACCORDION_SECTION}
+  ${ACCORDION_SECTION}
   ${ALERT}
   ${BANNER}
   ${BLOG_POSTS_PODCAST}

--- a/utils/strapi/queries.ts
+++ b/utils/strapi/queries.ts
@@ -1,3 +1,4 @@
+import { ACCORDION_SECTION } from "@/utils/strapi/sections/Accordion";
 import { ALERT } from "@/utils/strapi/sections/Alert";
 import { BANNER } from "@/utils/strapi/sections/Banner";
 import { BLOG_POSTS_PODCAST } from "@/utils/strapi/sections/BlogPostsPodcast";
@@ -17,6 +18,7 @@ import { PROMO_LINK_LIST } from "@/utils/strapi/sections/PromoLinkList";
 import { RICH_TEXT_IMAGE } from "@/utils/strapi/sections/RichTextImage";
 import { STATISTICS_CARD_LIST } from "@/utils/strapi/sections/StatisticsCardList";
 import { TEXT_CONTENT } from "@/utils/strapi/sections/TextContent";
+import type {AccordionSection} from "@/utils/strapi/sections/Accordion";
 import type { AlertSection } from "@/utils/strapi/sections/Alert";
 import type { BannerSection } from "@/utils/strapi/sections/Banner";
 import type { CardListSection } from "@/utils/strapi/sections/CardList";
@@ -37,6 +39,7 @@ import type { StatisticsCardListSection } from "@/utils/strapi/sections/Statisti
 import type { TextContentSection } from "@/utils/strapi/sections/TextContent";
 
 export type ComponentSection =
+  | AccordionSection
   | AlertSection
   | BannerSection
   | BlogPostsPodcastSection
@@ -57,6 +60,7 @@ export type ComponentSection =
   | TextContentSection
 
 export const SECTIONS = `
+${ACCORDION_SECTION}
   ${ALERT}
   ${BANNER}
   ${BLOG_POSTS_PODCAST}

--- a/utils/strapi/sections/Accordion.ts
+++ b/utils/strapi/sections/Accordion.ts
@@ -12,13 +12,13 @@ export type AccordionSection = {
 };
 
 export const ACCORDION_SECTION = `
-  ...on ComponentSectionsAccordion {
+...on ComponentSectionsAccordion {
+  title
+  subtitle
+  description
+  accordionItems {
     title
-    subtitle
-    description
-    accordionItems {
-      title
-      content
-    }
+    content
   }
-  `;
+}
+`;

--- a/utils/strapi/sections/Accordion.ts
+++ b/utils/strapi/sections/Accordion.ts
@@ -1,17 +1,17 @@
 type itemsAccordion = {
-    title: string;
-    content: string;
-  };
-  
-  export type AccordionSection = {
-    type: "ComponentSectionsAccordion";
-    title: string;
-    subtitle: string;
-    description: string;
-    accordionItems: Array<itemsAccordion>;
-  };
-  
-  export const ACCORDION_SECTION = `
+  title: string;
+  content: string;
+};
+
+export type AccordionSection = {
+  type: "ComponentSectionsAccordion";
+  title: string;
+  subtitle: string;
+  description: string;
+  accordionItems: Array<itemsAccordion>;
+};
+
+export const ACCORDION_SECTION = `
   ...on ComponentSectionsAccordion {
     title
     subtitle

--- a/utils/strapi/sections/Accordion.ts
+++ b/utils/strapi/sections/Accordion.ts
@@ -1,0 +1,24 @@
+type itemsAccordion = {
+    title: string;
+    content: string;
+  };
+  
+  export type AccordionSection = {
+    type: "ComponentSectionsAccordion";
+    title: string;
+    subtitle: string;
+    description: string;
+    accordionItems: Array<itemsAccordion>;
+  };
+  
+  export const ACCORDION_SECTION = `
+  ...on ComponentSectionsAccordion {
+    title
+    subtitle
+    description
+    accordionItems {
+      title
+      content
+    }
+  }
+  `;


### PR DESCRIPTION
## Issue
We nees to migrate Accordion component form UTEG repository 
PR migrated: [PR-#199 [DEV-5976] Components strapi inApp](https://github.com/techlottus/portalverse/pull/199/files)

## Solution
The Accordion component has been migrated from the UTEG repository to the UANE repository in order to render it in dynamic pages

<img width="1658" alt="Captura de pantalla 2023-08-16 a la(s) 15 32 03" src="https://github.com/techlottus/portalverse-uane/assets/116602156/70f2c94f-55fe-4145-8718-2de56f307444">

