### PR TITLE
[ENG-807] Add university extension course category on detail page

### DIFF
--- a/components/sections/ContEdProgramDetail.tsx
+++ b/components/sections/ContEdProgramDetail.tsx
@@ -15,6 +15,7 @@ const mxnCurrency = new Intl.NumberFormat("es-MX", {
 const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramAttributes) => {
   const { 
     name,
+    programCategory,
     detail,
     image,
     price,
@@ -28,7 +29,14 @@ const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramA
 
   return (
     <ContentLayout classNames="gap-6">
-      <div className="col-span-6 w-t:col-span-4 w-p:col-span-4">
+      <div className="col-span-6 w-t:col-span-4 w-p:col-span-4 ">
+        {
+          programCategory?.data?.attributes?.name ?
+          <div className="mb-4">
+            <h5 className="font-Poppins text-6 font-semibold">{programCategory?.data?.attributes?.name}</h5>
+          </div>
+          :null
+        }
         <div className="flex flex-col gap-6">
           {
             name ?
@@ -94,6 +102,6 @@ const ContinuousEducationProgramDetail: FC<ProgramAttributes> = (props: ProgramA
       </div>
     </ContentLayout>
   );
-};
+}
 
 export default ContinuousEducationProgramDetail;

--- a/utils/getProgramBySlug.ts
+++ b/utils/getProgramBySlug.ts
@@ -49,6 +49,13 @@ export type ProgramModalityDetail = {
 export type ProgramAttributes = {
   slug: string;
   name: string;
+  programCategory: {
+    data: {
+      attributes: {
+        name: string
+      }
+    }
+  }
   description: string;
   image: StrapiImage;
   detail: string;
@@ -89,6 +96,13 @@ query ProgramBySlug($slug: String!) {
       attributes {
         slug
         name
+        programCategory{
+          data{
+            attributes{
+              name
+            }
+          }
+        }
         description
         image {
           data {


### PR DESCRIPTION
## Issue
<!-- Please describe the current behavior that you are modifying. -->
we need to add the category above the title of each university extension program

## Solution
<!-- Please describe your changes -->
The detail model of the university extension program has been modified to add the category on the title of the program
The query has been modified to bring the data of the program category
the typing has been modified to add the property of the category of the program
